### PR TITLE
always report test results per test class

### DIFF
--- a/tests/RunTests.java
+++ b/tests/RunTests.java
@@ -107,7 +107,7 @@ public class RunTests extends MIDlet {
             System.err.println(e);
             harness.fail("Test threw an unexpected exception");
         }
-        if (harness.failed() > 0)
+        // if (harness.failed() > 0)
             harness.report();
         pass += harness.passed();
         fail += harness.failed();

--- a/tests/RunTests.java
+++ b/tests/RunTests.java
@@ -107,8 +107,7 @@ public class RunTests extends MIDlet {
             System.err.println(e);
             harness.fail("Test threw an unexpected exception");
         }
-        // if (harness.failed() > 0)
-            harness.report();
+        harness.report();
         pass += harness.passed();
         fail += harness.failed();
         knownFail += harness.knownFailed();


### PR DESCRIPTION
I made this to help @mbebenita debug a particular problem, but it's actually generally useful, and it doesn't push us past the magic 10,000 line limit in Travis, so I recommend we merge it.
