### PR TITLE
use Int8Array in filesystem APIs

### DIFF
--- a/libs/fs.js
+++ b/libs/fs.js
@@ -383,7 +383,7 @@ var fs = (function() {
       }
     }
 
-    var newArray = new Uint8Array(newBufferSize);
+    var newArray = new Int8Array(newBufferSize);
     newArray.set(this.array);
 
     this.array = newArray;
@@ -463,7 +463,7 @@ var fs = (function() {
         var fd = openedFiles.push({
           dirty: false,
           path: path,
-          buffer: new FileBuffer(new Uint8Array(reader.result)),
+          buffer: new FileBuffer(new Int8Array(reader.result)),
           mtime: record.mtime,
           size: record.size,
           position: 0,

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -493,7 +493,7 @@ Native["com/ibm/oti/connection/file/FCInputStream.readByteImpl.(I)I"] = function
 
     var data = fs.read(fd, curpos, curpos+1);
 
-    return (data.byteLength > 0) ? data[0] : -1;
+    return (data.byteLength > 0) ? (data[0] & 0xFF) : -1;
 };
 
 Native["com/ibm/oti/connection/file/FCInputStream.closeImpl.(I)V"] = function(fd) {
@@ -551,7 +551,7 @@ Native["com/ibm/oti/connection/file/FCOutputStream.syncImpl.(I)V"] = function(fd
 };
 
 Native["com/ibm/oti/connection/file/FCOutputStream.writeByteImpl.(II)V"] = function(val, fd) {
-    var buf = new Uint8Array(1);
+    var buf = new Int8Array(1);
     buf[0] = val;
     fs.write(fd, buf);
 };

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -70,7 +70,7 @@ var gfxTests = [
 ];
 
 var expectedUnitTestResults = [
-  { name: "pass", number: 71566 },
+  { name: "pass", number: 71565 },
   { name: "fail", number: 0 },
   { name: "known fail", number: 215 },
   { name: "unknown pass", number: 0 }

--- a/tests/com/sun/midp/publickeystore/TestInputOutputStorage.java
+++ b/tests/com/sun/midp/publickeystore/TestInputOutputStorage.java
@@ -33,7 +33,9 @@ public class TestInputOutputStorage implements Testlet {
     public void test(TestHarness th) {
         try {
             FileConnection file = (FileConnection)Connector.open("file:////prova");
-            th.check(!file.exists());
+            if (file.exists()) {
+                file.delete();
+            }
             file.create();
 
             RandomAccessStream ras = new RandomAccessStream();


### PR DESCRIPTION
This is a followup to #1024 that uses Int8Array in the filesystem APIs. FileConnection is funny, since it passes around bytes as ints. Thus we have to be careful to convert them back and forth.

This change also removes a common source of test failures when I'm testing locally: if *file:////prova* already exists (f.e. because I restarted tests during a run), then *TestInputOutputStorage* used to fail. But the purpose of that class is not to test for the existence of that file, it's to use that file to test the *InputStorage*/*OutputStorage* APIs. So it shouldn't fail if the file exists, it should simply recreate the file. Now it does.
