### PR TITLE
Use the same intern pool for compiler and interpreter.

### DIFF
--- a/string.js
+++ b/string.js
@@ -311,7 +311,7 @@ Override["java/lang/String.valueOf.(J)Ljava/lang/String;"] = function(n) {
 // Additionally, their tests check for coverage of nuanced things like
 // positive zero vs. negative zero, which we don't currently support.
 
-var internedStrings = new Map();
+var internedStrings = J2ME.internedStrings;
 
 Native["java/lang/String.intern.()Ljava/lang/String;"] = function() {
     var string = util.fromJavaString(this);


### PR DESCRIPTION
string.intern() and J2ME.newStringConstant were not using the same pool of strings which could lead to unexpected comparison results if using "==".
Unfortunately, we don't have a good test for this at the moment. 