### PR TITLE
Enable check for unwinding during static initializers.

### DIFF
--- a/runtime.ts
+++ b/runtime.ts
@@ -875,15 +875,8 @@ module J2ME {
         });
         initWriter && initWriter.writeLn("Running Static Constructor: " + classInfo.className);
         $.ctx.pushClassInitFrame(classInfo);
-        // release || assert(!U);
+        release || assert(!U, "Unwinding during static initializer not supported.");
 
-        //// TODO: monitorEnter
-        //if (klass.staticInitializer) {
-        //  klass.staticInitializer.call(runtimeKlass);
-        //}
-        //if (klass.staticConstructor) {
-        //  klass.staticConstructor.call(runtimeKlass);
-        //}
         return runtimeKlass;
       }
     });


### PR DESCRIPTION
Illuminates the problem in #1049 but does not fix it for now.