### PR TITLE
Remove midp.js and crypto.js from jsc.ts

### DIFF
--- a/jsc.ts
+++ b/jsc.ts
@@ -80,8 +80,8 @@ module J2ME {
 
   loadFiles("blackBox.js", "build/j2me-jsc.js", "libs/zipfile.js",
     "libs/encoding.js", "util.js",
-    "override.js", "native.js", "string.js", "midp/midp.js",
-    "libs/long.js", "midp/crypto.js", "libs/forge/md5.js", "libs/forge/util.js");
+    "override.js", "native.js", "string.js",
+    "libs/long.js", "libs/forge/md5.js", "libs/forge/util.js");
 
   phase = ExecutionPhase.Compiler;
 

--- a/jsc.ts
+++ b/jsc.ts
@@ -78,10 +78,7 @@ module J2ME {
     }
   }
 
-  loadFiles("blackBox.js", "build/j2me-jsc.js", "libs/zipfile.js",
-    "libs/encoding.js", "util.js",
-    "override.js", "native.js", "string.js",
-    "libs/long.js", "libs/forge/md5.js", "libs/forge/util.js");
+  loadFiles("blackBox.js", "build/j2me-jsc.js", "libs/zipfile.js", "libs/encoding.js", "util.js");
 
   phase = ExecutionPhase.Compiler;
 


### PR DESCRIPTION
This makes it so that in midp.js, we can use things like `Promise`,
`window.setInterval`, etc