### PR TITLE
Increase threshold for `getMediaTime`

### DIFF
--- a/tests/javax/microedition/media/TestAudioPlayer.java
+++ b/tests/javax/microedition/media/TestAudioPlayer.java
@@ -13,7 +13,7 @@ public class TestAudioPlayer implements Testlet, PlayerListener {
     public int getExpectedKnownFail() { return 0; }
     TestHarness th;
 
-    private static final long TIME_TOLERANCE = 100;
+    private static final long TIME_TOLERANCE = 175;
 
      /**
      * PlayerListener interface's method.


### PR DESCRIPTION
This fixes test failures that I'm seeing locally on master.