### PR TITLE
Ensure floatParam1 value of the native events sent by sendNativeEvent is float but not double

### DIFF
--- a/midp/midp.js
+++ b/midp/midp.js
@@ -583,7 +583,7 @@ MIDP.Context2D = (function() {
             intParam4: MIDP.displayId,
             intParam5: pt.x,
             intParam6: pt.y,
-            floatParam1: aFloatParam1 || 0.0,
+            floatParam1: Math.fround(aFloatParam1 || 0.0),
             intParam7: aIntParam7 || 0,
             intParam8: aIntParam8 || 0,
             intParam9: aIntParam9 || 0,


### PR DESCRIPTION
I get the following native method error scrolling the screen sometimes:
```
Native com/sun/midp/events/NativeEventMonitor.waitForNativeEvent.(Lcom/sun/midp/events/NativeEvent;)I throws: Error: Unexpected value for target $floatParam1
```

It is caused by a type check failure. The `floatParam1` attribute of `NativeEvent` is float, but we pass a double value in `sendGestureEvent()` for the `NativeEvent` instance.