### PR TITLE
Fix System.getProperty0("com.nokia.multisim.slots") return type.

### DIFF
--- a/native.js
+++ b/native.js
@@ -70,7 +70,7 @@ Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] 
 };
 
 var stubProperties = {
-  "com.nokia.multisim.slots": 1,
+  "com.nokia.multisim.slots": "1",
   "com.nokia.mid.imsi": "000000000000000",
   "com.nokia.mid.imei": "",
 };


### PR DESCRIPTION
System.getProperty0("com.nokia.multisim.slots") should return a string rather than a number.