### PR TITLE
Save OSR entry points for AOT code.

### DIFF
--- a/actors.ts
+++ b/actors.ts
@@ -6,8 +6,6 @@ module J2ME {
   declare var classObjects;
   declare var util;
 
-  import BlockMap = Bytecode.BlockMap;
-
   export interface ConstantPoolEntry {
     tag: TAGS;
     name_index: number;
@@ -134,7 +132,7 @@ module J2ME {
     mangledName: string;
     mangledClassAndMethodName: string;
 
-    blockMap: BlockMap;
+    onStackReplacementEntryPoints: number [];
 
     line_number_table: {start_pc: number; line_number: number} [];
 
@@ -229,7 +227,7 @@ module J2ME {
       this.bytecodeCount = 0;
 
       this.isOptimized = false;
-      this.blockMap = null;
+      this.onStackReplacementEntryPoints = null;
     }
 
     public getReturnKind(): Kind {

--- a/interpreter.ts
+++ b/interpreter.ts
@@ -260,15 +260,7 @@ module J2ME {
             // at the beggining of a basic block. This is a really cheap test and a convenient place to perform an
             // on stack replacement.
 
-            var blockMap = mi.blockMap;
-            if (!blockMap) {
-              blockMap = new BlockMap(mi);
-              blockMap.build();
-              mi.blockMap = blockMap;
-            }
-
-            var block = blockMap.getBlock(frame.pc);
-            if (block.isLoopHeader && !block.isInnerLoopHeader()) {
+            if (mi.onStackReplacementEntryPoints.indexOf(frame.pc) > -1) {
               onStackReplacementCount++;
 
               // The current frame will be swapped out for a JIT frame, so pop it off the interpreter stack.

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -283,7 +283,7 @@ module J2ME {
       if (this.hasMonitorEnter) {
         this.bodyEmitter.prependLn("var th = $.ctx.thread;");
       }
-      return new CompiledMethodInfo(this.parameters, this.bodyEmitter.toString(), this.referencedClasses, this.hasOSREntryPoint);
+      return new CompiledMethodInfo(this.parameters, this.bodyEmitter.toString(), this.referencedClasses, this.blockMap.getOSREntryPoints());
     }
 
     needsVariable(name: string) {

--- a/jit/blockMap.ts
+++ b/jit/blockMap.ts
@@ -134,6 +134,17 @@ module J2ME.Bytecode {
       return this.blockMap[bci];
     }
 
+    public getOSREntryPoints() {
+      var points = [];
+      for (var i = 0; i < this.blocks.length; i++) {
+        var block = this.blocks[i];
+        if (block.isLoopHeader && !block.isInnerLoopHeader()) {
+          points.push(block.startBci);
+        }
+      }
+      return points;
+    }
+
     private makeBlock(startBci: number): Block {
       var oldBlock = this.blockMap[startBci];
       if (!oldBlock) {

--- a/jit/compiler.ts
+++ b/jit/compiler.ts
@@ -217,6 +217,12 @@ module J2ME {
     return classInfo.className.replace(/\//g, '.');
   }
 
+  export function emitMethodMetaData(emitter: Emitter, methodInfo: MethodInfo, compiledMethodInfo: CompiledMethodInfo) {
+    var metaData = <AOTMetaData>Object.create(null);
+    metaData.osr = compiledMethodInfo.onStackReplacementEntryPoints;
+    emitter.writer.writeLn("AOTMD[\"" + methodInfo.mangledClassAndMethodName + "\"] = " + JSON.stringify(metaData) + ";");
+  }
+
   export function emitReferencedSymbols(emitter: Emitter, classInfo: ClassInfo, compiledMethods: CompiledMethodInfo []) {
     var referencedClasses = [];
     for (var i = 0; i < compiledMethods.length; i++) {
@@ -315,6 +321,7 @@ module J2ME {
               writer.writeLn("window[" + quote(mangledClassAndMethodName) + "] = " + mangledClassAndMethodName + ";");
             }
           }
+          emitMethodMetaData(emitter, method, compiledMethod);
           compiledMethods.push(compiledMethod);
         }
       } catch (x) {
@@ -339,7 +346,7 @@ module J2ME {
     constructor(public args: string [],
                 public body: string,
                 public referencedClasses: ClassInfo [],
-                public hasOSREntryPoint: boolean = false) {
+                public onStackReplacementEntryPoints: number [] = null) {
       // ...
     }
   }

--- a/main.js
+++ b/main.js
@@ -245,7 +245,8 @@ window.onload = function() {
 
     var el = document.getElementById("compiledCount");
     el.textContent = numberWithCommas(J2ME.compiledMethodCount) + " / " +
-                     numberWithCommas(J2ME.cachedMethodCount);
+                     numberWithCommas(J2ME.cachedMethodCount) + " / " +
+                     numberWithCommas(J2ME.aotMethodCount);
 
     var el = document.getElementById("onStackReplacementCount");
     el.textContent = numberWithCommas(J2ME.onStackReplacementCount);


### PR DESCRIPTION
In a subsequent PR I'll also be moving classSymbols into the new aotMetaData so we only initialized classes on a per method basis.