### PR TITLE
tolerate more different pixels for Ubuntu

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -65,7 +65,7 @@ var gfxTests = [
   { name: "gfx/CreateImmutableCopyTest", maxDifferent: 0 },
   { name: "gfx/LauncherTest", maxDifferent: 0 },
   { name: "gfx/MediaImageTest", maxDifferent: 0 },
-  { name: "gfx/TextEditorGfxTest", maxDifferent: 1339 },
+  { name: "gfx/TextEditorGfxTest", maxDifferent: 1375 },
   { name: "gfx/DrawStringWithCopyrightAndRegisteredSymbols", maxDifferent: 244 },
 ];
 


### PR DESCRIPTION
On my Ubuntu VM, TextEditorGfxTest has 1375 different pixels, although it looks correct (reference on left, actual on right):

![texteditorgfxtest](https://cloud.githubusercontent.com/assets/305455/6178742/d2fcec98-b2c6-11e4-9d87-a939d5fe0391.png) ![screen shot 2015-02-12 at 14 53 09](https://cloud.githubusercontent.com/assets/305455/6178774/0effa636-b2c7-11e4-9b53-779b5ee223a1.png)

