### PR TITLE
make travis bot report one line, not enter/leave, and use a notice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ notifications:
     channels:
       - "irc.mozilla.org#j2mejs"
     template:
-      - "%{repository_slug} - %{commit_message} - %{result} %{message} - %{build_url}"
+      - "%{repository_slug} - %{commit_message} - %{result} - %{build_url}"
     use_notice: true
     skip_join: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,10 @@ cache:
     - node_modules
     - /tmp/j2me.js
 notifications:
- irc: "irc.mozilla.org#j2mejs"
+  irc:
+    channels:
+      - "irc.mozilla.org#j2mejs"
+    template:
+      - "%{repository_slug} - %{commit_message} - %{result} %{message} - %{build_url}
+    use_notice: true
+    skip_join: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ notifications:
     channels:
       - "irc.mozilla.org#j2mejs"
     template:
-      - "%{repository_slug} - %{commit_message} - %{result} %{message} - %{build_url}
+      - "%{repository_slug} - %{commit_message} - %{result} %{message} - %{build_url}"
     use_notice: true
     skip_join: true


### PR DESCRIPTION
Make the Travis bot report one line, not enter/leave, and use a notice to reduce the noise in the IRC channel. This may need a bit of massaging to make the message be succinct yet informative. Hard to tell until I see what Travis reports in the channel as a result.
