### PR TITLE
Cache context2D on `Graphics` objects

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -413,20 +413,6 @@ var currentlyFocusedTextEditor;
     var BOTTOM = 32;
     var BASELINE = 64;
 
-    function withGraphics(g) {
-        var img = g.img,
-            c = null;
-
-        if (img === null) {
-            c = MIDP.Context2D;
-        } else {
-            var imgData = img.imageData,
-                c = imgData.context;
-        }
-
-        return c;
-    }
-
     function withClip(g, c, x, y) {
         if (g.clipped) {
             c.beginPath();
@@ -813,7 +799,7 @@ var currentlyFocusedTextEditor;
 
         context.putImageData(imageData, 0, 0);
 
-        var c = withGraphics(graphics);
+        var c = graphics.context2D;
         if (graphics.clipped) {
             c.save();
         }
@@ -836,7 +822,7 @@ var currentlyFocusedTextEditor;
     function renderImage(g, image, x, y, anchor) {
         var texture = image.imageData.context.canvas;
 
-        var c = withGraphics(g);
+        var c = g.context2D;
         if (g.clipped) {
             c.save();
         }
@@ -1001,12 +987,14 @@ var currentlyFocusedTextEditor;
         this.displayId = displayId;
         setDimensions(this, w, h);
         resetGC(this);
+        this.context2D = MIDP.Context2D;
     };
 
     Native["javax/microedition/lcdui/Graphics.initImage0.(Ljavax/microedition/lcdui/Image;II)V"] = function(img, w, h) {
         this.img = img;
         setDimensions(this, w, h);
         resetGC(this);
+        this.context2D = img.imageData.context;
     };
 
     function isScreenGraphics(g) {
@@ -1142,7 +1130,7 @@ var currentlyFocusedTextEditor;
     function drawString(g, str, x, y, anchor, isOpaque) {
         var font = g.currentFont;
 
-        var c = withGraphics(g);
+        var c = g.context2D;
         if (g.clipped) {
             c.save();
         }
@@ -1200,7 +1188,7 @@ var currentlyFocusedTextEditor;
     Native["javax/microedition/lcdui/Graphics.drawChar.(CIII)V"] = function(jChr, x, y, anchor) {
         var chr = String.fromCharCode(jChr);
 
-        var c = withGraphics(this);
+        var c = this.context2D;
         if (this.clipped) {
             c.save();
         }
@@ -1221,7 +1209,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.fillTriangle.(IIIIII)V"] = function(x1, y1, x2, y2, x3, y3) {
-        var c = withGraphics(this);
+        var c = this.context2D;
         if (this.clipped) {
             c.save();
         }
@@ -1254,7 +1242,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = withGraphics(this);
+        var c = this.context2D;
         if (this.clipped) {
             c.save();
         }
@@ -1280,7 +1268,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = withGraphics(this);
+        var c = this.context2D;
         if (this.clipped) {
             c.save();
         }
@@ -1308,7 +1296,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = withGraphics(this);
+        var c = this.context2D;
         if (this.clipped) {
             c.save();
         }
@@ -1334,7 +1322,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = withGraphics(this);
+        var c = this.context2D;
         if (this.clipped) {
             c.save();
         }
@@ -1362,7 +1350,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = withGraphics(this);
+        var c = this.context2D;
 
         withPixel(this, c);
 
@@ -1378,7 +1366,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = withGraphics(this);
+        var c = this.context2D;
 
         withPixel(this, c);
 
@@ -1404,7 +1392,7 @@ var currentlyFocusedTextEditor;
         var imgData = image.imageData,
             texture = imgData.context.canvas;
 
-        var c = withGraphics(g);
+        var c = g.context2D;
         if (g.clipped || transform !== TRANS_NONE) {
             c.save();
         }
@@ -1435,7 +1423,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.drawLine.(IIII)V"] = function(x1, y1, x2, y2) {
-        var c = withGraphics(this);
+        var c = this.context2D;
         if (this.clipped) {
             c.save();
         }
@@ -1477,7 +1465,7 @@ var currentlyFocusedTextEditor;
 
         context.putImageData(imageData, 0, 0);
 
-        var c = withGraphics(this);
+        var c = this.context2D;
         if (this.clipped) {
             c.save();
         }


### PR DESCRIPTION
This eliminates the need for the `withGraphics` function; instead of
calling a function every time we want a context from a `Graphics`
object, we can just cache the context so it's readily available.