### PR TITLE
Some optimizations for the CompiledMethodCache

### DIFF
--- a/libs/compiled-method-cache.js
+++ b/libs/compiled-method-cache.js
@@ -120,7 +120,9 @@ var CompiledMethodCache = (function() {
 
   function get(key) {
     var elem = cache.get(key);
-    cache.delete(key);
+    if (elem) {
+      cache.delete(key);
+    }
     return elem;
   }
 

--- a/libs/compiled-method-cache.js
+++ b/libs/compiled-method-cache.js
@@ -119,7 +119,9 @@ var CompiledMethodCache = (function() {
   });
 
   function get(key) {
-    return cache.get(key);
+    var elem = cache.get(key);
+    cache.delete(key);
+    return elem;
   }
 
   var recordsToFlush = [];

--- a/libs/compiled-method-cache.js
+++ b/libs/compiled-method-cache.js
@@ -149,7 +149,6 @@ var CompiledMethodCache = (function() {
 
   function put(obj) {
     DEBUG && debug("put " + obj[KEY_PATH]);
-    cache.set(obj[KEY_PATH], obj);
     recordsToFlush.push(obj);
     if (!flushTimer) {
       flushTimer = setTimeout(flush, 3000 /* ms; 3 seconds */);


### PR DESCRIPTION
I think we can safely remove methods from the cache once we've retrieved them and we don't need to put them in the cache Map (but we only need to store them in the DB).
All the users of CompiledMethodCache are going to eval the method after *get* or before *put*, so the method is always going to be in memory (and so a method is never going to be retrieved twice or retrieved after put).