### PR TITLE
use commit_subject so IRC notices are correct for merge commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ notifications:
     channels:
       - "irc.mozilla.org#j2me.js"
     template:
-      - "%{repository_slug} - %{commit_message} - %{result} - %{build_url}"
+      - "%{repository_slug} - %{commit_subject} - %{result} - %{build_url}"
     use_notice: true
     skip_join: true


### PR DESCRIPTION
Per https://github.com/travis-ci/travis-ci/issues/2539#issuecomment-74608386 and https://github.com/travis-ci/travis-tasks/pull/30, this should fix the issue with IRC notices of merge commits.
