### PR TITLE
replace transient paths with ignored files

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -24,7 +24,7 @@ var config = {
   // writes to them and return no data from reads.  It's useful for log files
   // to which midlets write frequently but never read.  Specify one by setting
   // a string pathname key to the boolean true value.
-  ignoredFiles: new Map(),
+  ignoredFiles: new Set(),
 };
 
 // The base directory of the app, relative to the current page.  Normally this

--- a/config/default.js
+++ b/config/default.js
@@ -22,8 +22,8 @@ var config = {
 
   // Ignored files are files that always exist and are empty, so we discard
   // writes to them and return no data from reads.  It's useful for log files
-  // to which midlets write frequently but never read.  Specify one by setting
-  // a string pathname key to the boolean true value.
+  // to which midlets write frequently but never read.  Specify one by adding
+  // the string pathname to the set via config.ignoredFiles.add().
   ignoredFiles: new Set(),
 };
 

--- a/config/default.js
+++ b/config/default.js
@@ -19,6 +19,12 @@ var MIDlet = {
 var config = {
   main: "com/sun/midp/main/MIDletSuiteLoader",
   midletClassName: "RunTests",
+
+  // Ignored files are files that always exist and are empty, so we discard
+  // writes to them and return no data from reads.  It's useful for log files
+  // to which midlets write frequently but never read.  Specify one by setting
+  // a string pathname key to the boolean true value.
+  ignoredFiles: new Map(),
 };
 
 // The base directory of the app, relative to the current page.  Normally this

--- a/main.js
+++ b/main.js
@@ -161,7 +161,8 @@ if (config.downloadJAD) {
 if (jars.indexOf("tests/tests.jar") !== -1) {
   loadingPromises.push(loadScript("tests/native.js"),
                        loadScript("tests/override.js"),
-                       loadScript("tests/mozactivitymock.js"));
+                       loadScript("tests/mozactivitymock.js"),
+                       loadScript("tests/config.js"));
 }
 
 loadingPromises.push(emoji.loadData());

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -262,6 +262,10 @@ Native["com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V"] 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.create: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.create: ignored file");
+        return;
+    }
 
     var stat = fs.stat(pathname);
 
@@ -272,22 +276,39 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function() {
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
+    DEBUG_FS && console.log("DefaultFileHandler.exists: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.exists: ignored file");
+        return 1;
+    }
+
     var exists = fs.exists(pathname);
-    DEBUG_FS && console.log("DefaultFileHandler.exists: " + pathname + " " + exists);
+    DEBUG_FS && console.log("DefaultFileHandler.exists: " + exists);
     return exists ? 1 : 0;
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
+    DEBUG_FS && console.log("DefaultFileHandler.isDirectory: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.isDirectory: ignored file");
+        return 0;
+    }
+
     var stat = fs.stat(pathname);
     var isDirectory = !!stat && stat.isDir;
-    DEBUG_FS && console.log("DefaultFileHandler.isDirectory: " + pathname + " " + isDirectory);
+    DEBUG_FS && console.log("DefaultFileHandler.isDirectory: " + isDirectory);
     return isDirectory ? 1 : 0;
 }
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.delete: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.delete: ignored file");
+        return;
+    }
+
     if (!fs.remove(pathname)) {
         throw $.newIOException();
     }
@@ -311,6 +332,10 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(byteOffset) {
     var pathname = util.fromJavaString(this.$nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.lastModified: ignored file");
+        return;
+    }
 
     var stat = fs.stat(pathname);
 
@@ -330,6 +355,10 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(b
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.fileSize.()J"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.fileSize: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.fileSize: ignored file");
+        return Long.fromNumber(0);
+    }
 
     return Long.fromNumber(fs.size(pathname));
 };
@@ -339,12 +368,22 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.directorySiz
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.canRead: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.canRead: ignored file");
+        return 1;
+    }
+
     return fs.exists(pathname) ? 1 : 0;
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canWrite.()Z"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.canWrite: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.canWrite: ignored file");
+        return 1;
+    }
+
     return fs.exists(pathname) ? 1 : 0;
 };
 
@@ -356,6 +395,12 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isHidden0.()Z"] = function()
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
+    DEBUG_FS && console.log("DefaultFileHandler.setReadable: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.setReadable: ignored file");
+        return;
+    }
+
     if (!fs.exists(pathname)) {
         throw $.newIOException("file does not exist");
     }
@@ -365,6 +410,12 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = functio
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
+    DEBUG_FS && console.log("DefaultFileHandler.setWritable: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.setWritable: ignored file");
+        return;
+    }
+
     if (!fs.exists(pathname)) {
         throw $.newIOException("file does not exist");
     }
@@ -392,6 +443,11 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.totalSize.()
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.lastModified.()J"] = function() {
     var pathname = util.fromJavaString(this.$nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.lastModified: ignored file");
+        return Long.fromNumber(0);
+    }
+
     var stat = fs.stat(pathname);
     return Long.fromNumber(stat != null ? stat.mtime : 0);
 };
@@ -410,6 +466,10 @@ MIDP.markFileHandler = function(fileHandler, mode, state) {
 MIDP.openFileHandler = function(fileHandler, mode) {
     var pathname = util.fromJavaString(fileHandler.$nativePath);
     DEBUG_FS && console.log("MIDP.openFileHandler: " + pathname + " for " + mode);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("MIDP.openFileHandler: ignored file");
+        return;
+    }
 
     if (fileHandler.$nativeDescriptor !== -1) {
         // The file is already open, so we only have to reset its position
@@ -442,6 +502,10 @@ MIDP.openFileHandler = function(fileHandler, mode) {
 MIDP.closeFileHandler = function(fileHandler, mode) {
     var pathname = util.fromJavaString(fileHandler.$nativePath);
     DEBUG_FS && console.log("MIDP.closeFileHandler: " + pathname + " for " + mode);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("MIDP.closeFileHandler: ignored file");
+        return;
+    }
 
     MIDP.markFileHandler(fileHandler, mode, false);
 
@@ -486,7 +550,13 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForReadWrite.()V"] = fu
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(b, off, len) {
-    DEBUG_FS && console.log("DefaultFileHandler.read: " + util.fromJavaString(this.$nativePath));
+    var pathname = util.fromJavaString(this.$nativePath);
+    DEBUG_FS && console.log("DefaultFileHandler.read: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.read: ignored file");
+        return -1;
+    }
+
     var fd = this.$nativeDescriptor;
 
     if (off < 0 || len < 0 || off > b.byteLength || (b.byteLength - off) < len) {
@@ -505,7 +575,13 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(b,
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(b, off, len) {
-    DEBUG_FS && console.log("DefaultFileHandler.write: " + util.fromJavaString(this.$nativePath));
+    var pathname = util.fromJavaString(this.$nativePath);
+    DEBUG_FS && console.log("DefaultFileHandler.write: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.write: ignored file");
+        return len;
+    }
+
     var fd = this.$nativeDescriptor;
     fs.write(fd, b.subarray(off, off + len));
     // The "length of data really written," which is always the length requested
@@ -514,13 +590,25 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(b
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = function(offset) {
-    DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + util.fromJavaString(this.$nativePath));
+    var pathname = util.fromJavaString(this.$nativePath);
+    DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: ignored file");
+        return;
+    }
+
     var fd = this.$nativeDescriptor;
     fs.setpos(fd, offset.toNumber());
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function() {
-    DEBUG_FS && console.log("DefaultFileHandler.flush: " + util.fromJavaString(this.$nativePath));
+    var pathname = util.fromJavaString(this.$nativePath);
+    DEBUG_FS && console.log("DefaultFileHandler.flush: " + pathname);
+    if (config.ignoredFiles.has(pathname)) {
+        DEBUG_FS && console.log("DefaultFileHandler.flush: ignored file");
+        return;
+    }
+
     var fd = this.$nativeDescriptor;
     fs.flush(fd);
 };

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,0 +1,6 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+config.ignoredFiles.set("/Private/ignored-file", true);

--- a/tests/config.js
+++ b/tests/config.js
@@ -3,4 +3,4 @@
 
 'use strict';
 
-config.ignoredFiles.set("/Private/ignored-file", true);
+config.ignoredFiles.add("/Private/ignored-file");

--- a/tests/fs/automation.js
+++ b/tests/fs/automation.js
@@ -55,7 +55,7 @@ casper.test.begin("fs tests", 7, function(test) {
     casper
     .thenOpen("http://localhost:8000/tests/fs/fstests.html")
     .waitForText("DONE", function() {
-        test.assertTextExists("DONE: 138 pass, 0 fail", "run fs.js unit tests");
+        test.assertTextExists("DONE: 137 pass, 0 fail", "run fs.js unit tests");
     });
 
     casper
@@ -78,7 +78,7 @@ casper.test.begin("fs tests", 7, function(test) {
     casper
     .thenOpen("http://localhost:8000/tests/fs/fstests.html")
     .waitForText("DONE", function() {
-        test.assertTextExists("DONE: 138 pass, 0 fail", "run fs.js unit tests");
+        test.assertTextExists("DONE: 137 pass, 0 fail", "run fs.js unit tests");
     });
 
     casper
@@ -101,7 +101,7 @@ casper.test.begin("fs tests", 7, function(test) {
     casper
     .thenOpen("http://localhost:8000/tests/fs/fstests.html")
     .waitForText("DONE", function() {
-        test.assertTextExists("DONE: 138 pass, 0 fail", "run fs.js unit tests");
+        test.assertTextExists("DONE: 137 pass, 0 fail", "run fs.js unit tests");
     });
 
     // Run the FileConnection TCK unit tests.

--- a/tests/fs/fstests.js
+++ b/tests/fs/fstests.js
@@ -871,19 +871,6 @@ tests.push(function() {
   });
 });
 
-tests.push(function() {
-  fs.addTransientPath("/transient-path");
-  fs.create("/transient-path", new Blob());
-  fs.open("/transient-path", function(fd) {
-    fs.write(fd, new TextEncoder().encode("marco"));
-    fs.close(fd);
-    fs.purgeStore();
-    var exists = fs.exists("/transient-path");
-    is(exists, false, "transient file doesn't exist after purge");
-    next();
-  });
-});
-
 // Export the fs store, import it again, and verify that the state of the fs
 // is equivalent.
 tests.push(function() {


### PR DESCRIPTION
To save memory (and improve perf), we should completely ignore files that midlets write and never read, replacing "transient paths" with "ignored files."
