### PR TITLE
support FxOS 1.1 via polyfills, parseInt, postMessage fixes, etc.

### DIFF
--- a/libs/pipe.js
+++ b/libs/pipe.js
@@ -79,11 +79,11 @@ var DumbPipe = {
   },
 
   receiveMessage: function(event) {
-    if (event.source === window) {
+    var envelope = event.data;
+
+    if (typeof envelope !== "object" || !("pipeID" in envelope)) {
       return;
     }
-
-    var envelope = event.data;
 
     if (this.recipients[envelope.pipeID]) {
       try {

--- a/main.html.in
+++ b/main.html.in
@@ -27,6 +27,7 @@
   <script type="text/javascript" src="polyfill/fromcodepoint.js" defer></script>
   <script type="text/javascript" src="polyfill/codepointat.js" defer></script>
   <script type="text/javascript" src="polyfill/IndexedDB-getAll-shim.js" defer></script>
+  <script type="text/javascript" src="polyfill/map.js" defer></script>
   <script type="text/javascript" src="legacy.js" defer></script>
   <script type="text/javascript" src="blackBox.js" defer></script>
   <script type="text/javascript" src="timer.js" defer></script>

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -137,6 +137,10 @@ var currentlyFocusedTextEditor;
         }
     }
 
+    var ABGRToRGB565_R_MASK = parseInt("000000000000000011111000", 2);
+    var ABGRToRGB565_G_MASK = parseInt("000000001111110000000000", 2);
+    var ABGRToRGB565_B_MASK = parseInt("111110000000000000000000", 2);
+
     function ABGRToRGB565(abgrData, rgbData, width, height, offset, scanlength) {
         var i = 0;
         for (var y = 0; y < height; y++) {
@@ -144,9 +148,9 @@ var currentlyFocusedTextEditor;
 
             for (var x = 0; x < width; x++) {
                 var abgr = abgrData[i++];
-                rgbData[j++] = (abgr & 0b000000000000000011111000) << 8 |
-                               (abgr & 0b000000001111110000000000) >>> 5 |
-                               (abgr & 0b111110000000000000000000) >>> 19;
+                rgbData[j++] = (abgr & ABGRToRGB565_R_MASK) << 8 |
+                               (abgr & ABGRToRGB565_G_MASK) >>> 5 |
+                               (abgr & ABGRToRGB565_B_MASK) >>> 19;
             }
         }
     }

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -927,7 +927,7 @@ var MIDP = (function() {
     $.stop();
     DumbPipe.open("exit", null, function(message) {});
     document.getElementById("exit-screen").style.display = "block";
-  };
+  }
 
   var pendingMIDletUpdate = null;
 
@@ -1194,8 +1194,8 @@ var MIDP = (function() {
     console.warn("CommandState.saveCommandState.(L...CommandState;)V not implemented (" + commandState + ")");
   };
 
-  Native["com/sun/midp/main/CommandState.exitInternal.(I)V"] = function(exit) {
-    console.info("Exit: " + exit);
+  Native["com/sun/midp/main/CommandState.exitInternal.(I)V"] = function(status) {
+    console.info("Exit: " + status);
     exit();
   };
 

--- a/polyfill/map.js
+++ b/polyfill/map.js
@@ -1,0 +1,20 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+if (!Map.prototype.clear) {
+  Map.prototype.clear = function() {
+    for (var keyVal of this) {
+      this.delete(keyVal[0]);
+    }
+  };
+}
+
+if (!Map.prototype.forEach) {
+  Map.prototype.forEach = function(callback, thisArg) {
+    for (var keyVal of this) {
+      callback.call(thisArg || null, keyVal[1], keyVal[0], this);
+    }
+  }
+}


### PR DESCRIPTION
This branch fixes a few issues on FxOS 1.1 (Gecko 18):

1. Polyfill *Map.clear* and *Map.forEach*.
2. Replace `0b*` binary literals with `parseInt(*, 2)` (not *Number.parseInt*, which also came later).
3. Update the criteria in *DumbPipe.receiveMessage* for which *postMessage* messages to ignore, as `event.source === window` for some reason, even though the messages come from the parent frame.

Regarding that last change, the primary reason we were ignoring messages when `event.source === window` was to weed out *setZeroTimeout* messages, which no longer exist now that *setZeroTimeout* is using *Promise.resolved*.

But there are still some other users of *postMessage*, particularly the promise-6.0.0.js polyfill, which we use on 1.1. So it's still useful to weed out unrelated messages. We just need to be more careful to target the right ones.

I also fixed a bug in the *CommandState.exitInternal* native, whose *exit* parameter masked the *exit* function it tries to call.

With these changes, the app downloads a midlet JAR I'm testing and starts its background midlet in the VM, but the midlet hits this exception:

>java.lang.IllegalStateException
> - java/lang/RuntimeException.<init>(), bci=0
> - java/lang/IllegalStateException.<init>(), bci=0
> - com/sun/midp/l10n/LocalizedStrings.getString(), bci=0
> - com/sun/midp/i18n/Resource.getString(), bci=0
> - com/sun/midp/main/HeadlessAlert.<init>(), bci=0
> - com/sun/midp/main/CldcForegroundController.registerDisplay(), bci=0
> - javax/microedition/lcdui/Display.<init>(), bci=0
> - javax/microedition/lcdui/Display.addDisplays(), bci=0
> - javax/microedition/lcdui/Display.getDisplay(), bci=0
> - javax/microedition/lcdui/Display.getDisplay(), bci=0
> - javax/microedition/midlet/MIDlet.<init>(), bci=0
> - BACKGROUND/MIDLET.<init>(), bci=0
> - BACKGROUND/MIDLET.ClassNewInstanceSynthetic(), bci=0
> - com/sun/midp/main/CldcMIDletLoader.newInstance(), bci=0
> - com/sun/midp/midlet/MIDletStateHandler.createMIDlet(), bci=0
> - com/sun/midp/midlet/MIDletStateHandler.createAndRegisterMIDlet(), bci=0
> - com/sun/midp/midlet/MIDletStateHandler.startSuite(), bci=0
> - com/sun/midp/main/AbstractMIDletSuiteLoader.startSuite(), bci=0
> - com/sun/midp/main/CldcMIDletSuiteLoader.startSuite(), bci=0
> - com/sun/midp/main/AbstractMIDletSuiteLoader.runMIDletSuite(), bci=0
> - com/sun/midp/main/MIDletSuiteLoader.main(), bci=0
> - com/sun/midp/l10n/LocalizedStrings.getString(), bci=4
> - com/sun/midp/i18n/Resource.getString(), bci=9
> - com/sun/midp/main/HeadlessAlert.<init>(), bci=7
> - com/sun/midp/main/CldcForegroundController.registerDisplay(), bci=21
> - javax/microedition/lcdui/Display.<init>(), bci=105
> - javax/microedition/lcdui/Display.addDisplays(), bci=36
> - javax/microedition/lcdui/Display.getDisplay(), bci=18
> - javax/microedition/lcdui/Display.getDisplay(), bci=4
> - javax/microedition/midlet/MIDlet.<init>(), bci=19
> - BACKGROUND/MIDLET.<init>(), bci=4
> - BACKGROUND/MIDLET.ClassNewInstanceSynthetic(), bci=7
> - com/sun/midp/main/CldcMIDletLoader.newInstance(), bci=31
> - com/sun/midp/midlet/MIDletStateHandler.createMIDlet(), bci=70
> - com/sun/midp/midlet/MIDletStateHandler.createMIDlet(), bci=125
> - com/sun/midp/midlet/MIDletStateHandler.createMIDlet(), bci=134
> - com/sun/midp/midlet/MIDletStateHandler.createMIDlet(), bci=142
> - com/sun/midp/midlet/MIDletStateHandler.createAndRegisterMIDlet(), bci=20
> - com/sun/midp/midlet/MIDletStateHandler.startSuite(), bci=29
> - com/sun/midp/main/AbstractMIDletSuiteLoader.startSuite(), bci=54
> - com/sun/midp/main/CldcMIDletSuiteLoader.startSuite(), bci=11
> - com/sun/midp/main/AbstractMIDletSuiteLoader.runMIDletSuite(), bci=146

After which *CommandState.exitInternal* is called with *status* `2001`, and the app exits. So there's more to do.
