### PR TITLE
Continue loading jars after first one is processed.

### DIFF
--- a/vm/classRegistry.ts
+++ b/vm/classRegistry.ts
@@ -209,6 +209,7 @@ module J2ME {
           CLASSES.getClass(className);
           return true;
         });
+        return true;
       });
     }
 


### PR DESCRIPTION
We returned undefined, so subsequent jars weren't loaded.