### PR TITLE
optimize dumb pipe

### DIFF
--- a/index.js.in
+++ b/index.js.in
@@ -53,6 +53,10 @@ var DumbPipe = {
       return;
     }
 
+    window.setZeroTimeout(this.handlePipeEvent.bind(this, event));
+  },
+
+  handlePipeEvent: function(event) {
     if (event.detail.promptType == "custom-prompt") {
       console.warn("unresponsive script warning; figure out how to handle");
       return;

--- a/libs/pipe.js
+++ b/libs/pipe.js
@@ -45,11 +45,8 @@ var DumbPipe = {
   sendQueue: [],
   isRunningSendQueue: false,
 
-  send: function(envelope, callback) {
-    this.sendQueue.push({
-      envelope: envelope,
-      callback: callback,
-    });
+  send: function(envelope) {
+    this.sendQueue.push(envelope);
 
     if (!this.isRunningSendQueue) {
       this.isRunningSendQueue = true;
@@ -58,18 +55,7 @@ var DumbPipe = {
   },
 
   runSendQueue: function() {
-    var item = this.sendQueue.shift();
-
-    if (item.callback) {
-      var result = JSON.parse(prompt(JSON.stringify(item.envelope)));
-      try {
-        item.callback(result);
-      } catch(ex) {
-        console.error(ex + "\n" + ex.stack);
-      }
-    } else {
-      alert(JSON.stringify(item.envelope));
-    }
+    alert(JSON.stringify(this.sendQueue.shift()));
 
     if (this.sendQueue.length > 0) {
       window.setZeroTimeout(this.runSendQueue.bind(this));


### PR DESCRIPTION
The primary optimization is to do most of the work of handling a DumbPipe event in the parent frame after a timeout, to reduce the amount of time the child frame is hung (since sending the event requires opening a modal *alert*).

A secondary optimization is to remove the support for sending an event with a callback, since we don't use that anymore.

With these changes, a simple test midlet spends half as much time in *DumbPipe.runSendQueue* in my profiles. This should improve the responsiveness of midlets that use privileged APIs (f.e. for TCP sockets).
