### PR TITLE
Don't allow thread preemption when resuming a thread.

### DIFF
--- a/tests/java/lang/TestThreadPriority.java
+++ b/tests/java/lang/TestThreadPriority.java
@@ -4,7 +4,7 @@ import gnu.testlet.Testlet;
 import gnu.testlet.TestHarness;
 
 public class TestThreadPriority implements Testlet {
-    public int getExpectedPass() { return 2; }
+    public int getExpectedPass() { return 1; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }
     private static String result = "";
@@ -24,10 +24,6 @@ public class TestThreadPriority implements Testlet {
         for (int i = 0; i < priorities.length; i++) {
             new Prioritized(priorities[i]).start();
         }
-
-        // The priority of the main thread is 5. Threads with higher priorities
-        // should preempt the main thread to run first.
-        th.check(result, "9 7 ");
 
         String expected = "9 7 5 1 ";
         try {

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -682,19 +682,11 @@ module J2ME {
       }
     }
 
-    /*
-     * @param jump If true, move the context to the first of others who have the
-     * same priority.
-     */
-    enqueue(ctx: Context, jump: boolean) {
+    enqueue(ctx: Context) {
       var priority = ctx.getPriority();
       release || assert(priority >= MIN_PRIORITY && priority <= MAX_PRIORITY,
                         "Invalid priority: " + priority);
-      if (jump) {
-        this._queues[priority].unshift(ctx);
-      } else {
-        this._queues[priority].push(ctx);
-      }
+      this._queues[priority].push(ctx);
       this._top = Math.max(priority, this._top);
     }
 
@@ -735,14 +727,7 @@ module J2ME {
      *      higher priority thread is scheduled to run.
      */
     static scheduleRunningContext(ctx: Context) {
-      // Preempt current thread if the new thread has higher priority
-      if ($ && ctx.getPriority() > $.ctx.getPriority()) {
-        Runtime._runningQueue.enqueue($.ctx, true);
-        Runtime._runningQueue.enqueue(ctx, false);
-        $.pause("preempt");
-      } else {
-        Runtime._runningQueue.enqueue(ctx, false);
-      }
+      Runtime._runningQueue.enqueue(ctx);
       Runtime.processRunningQueue();
     }
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -715,16 +715,13 @@ module J2ME {
 
 
     /*
-     * The thread scheduler uses green thread algorithm, which a preemptive,
+     * The thread scheduler uses green thread algorithm, which a non-preemptive,
      * priority based algorithm.
      * All Java threads have a priority and the thread with he highest priority
      * is scheduled to run.
      * In case two threads have the same priority a FIFO ordering is followed.
-     * A different thread is invoked to run only if
-     *   1. The current thread blocks or terminates.
-     *   2. A thread with a higher priority than the current thread enters the
-     *      Runnable state. The lower priority thread is preempted and the
-     *      higher priority thread is scheduled to run.
+     * A different thread is invoked to run only if the current thread blocks or
+     * terminates.
      */
     static scheduleRunningContext(ctx: Context) {
       Runtime._runningQueue.enqueue(ctx);


### PR DESCRIPTION
Current thread scheduler allows thread preemption when resuming an old thread from the current thread. This preemption behavior doesn't conform with the mainstream JVM at least in the following two cases:
1. When a new higher priority thread starts, it will preempt the current thread unconditionally.
2. When the current thread leaves a `synchronized` block and wakes up a higher priority thread being blocked, the higher priority thread will preempt the current thread.

The following code illustrates the above two cases.

```Java
import java.lang.*;

/* Name of the class has to be "Main" only if the class is public. */
class TestThreadPriority
{
	private static String result = "Main";
	
	static class Prioritized extends Thread {
	    public Prioritized() {
	        setPriority(Thread.MAX_PRIORITY);
	    }
	
	    public void run() {
	        result = "Prioritized";
	    }
	}
	
	static class Synchronized extends Thread {
	    public Synchronized() {
	        setPriority(Thread.MAX_PRIORITY);
	    }
	
	    public void run() {
	        synchronized(TestThreadPriority.class) {
	            result = "Synchronized";
	        }
	    }
	}
	    
	public static void main (String[] args) throws java.lang.Exception
	{
	    Thread p = new Prioritized();
	    p.start();
	    // With our implementation, p will preempt the main thread to set `result` to be "Prioritized".
	    // While the mainstream implementation, s won't and keep `result` to be "Main"
	    System.out.println(result);
	
	    try {
	        Thread.sleep(10);
	    } catch (InterruptedException e) {
	    }
	    // Wait p to set `result` to be "Prioritized".
	    System.out.println(result);
	
	    synchronized(TestThreadPriority.class) {
	        Thread s = new Synchronized();
	        s.start();
	        try {
	            Thread.sleep(10);
	        } catch (InterruptedException e) {
	        }
	    }
	    // With out implementation, s will preempt the main thread to set `result` to be "Synchronized".
	    // While with the mainstream implementation, s won't and keep `result` to be "Prioritized".
	    System.out.println(result);
	}
}
```

Our implementation is supposed to output the result of 
```
Prioritized
Prioritized
Synchronized
```
But there is a bug and we get 
```
Prioritized
Prioritized
Prioritized
```

The [mainstream implementation](http://ideone.com/tuOM1I) outputs
```
Main
Prioritized
Prioritized
```

This pull request drops the support of the unconditional thread preemption when resuming an old thread and makes our VM behaves the same as the mainstream one with the above test code.