### PR TITLE
Remove LocationListener after test.

### DIFF
--- a/tests/javax/microedition/location/TestLocation.java
+++ b/tests/javax/microedition/location/TestLocation.java
@@ -26,9 +26,6 @@ public class TestLocation implements Testlet, LocationListener {
             e.printStackTrace();
             th.fail("Unexpected exception: " + e);
         }
-        // TODO There is an unknown bug that causes the following line blocking
-        // the VM.
-        // provider.setLocationListener(null, -1, -1, -1);
         synchronized(this) {
             this.notify();
         }
@@ -46,6 +43,7 @@ public class TestLocation implements Testlet, LocationListener {
             synchronized(this) {
                 this.wait();
             }
+            provider.setLocationListener(null, -1, -1, -1);
             th.pass();
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
This fixes the TestLocation.java.
We had bug that `LocationListener` cannot be removed after test by calling `provider.setLocationListener` with a null value. The reason is that when we tried to  calling `provider.setLocationListener` within `LocationListener.locationUpdated`,  `provider.setLocationListener` in turn calls `LocationListener.locationUpdated` and `LocationListener.locationUpdated` calls `provider.setLocationListener` again. Then we enter an infinite loop and make the VM hang.

We could fix this simply by moving `provider.setLocationListener` out of `LocationListener.locationUpdated`.