### PR TITLE
When a thread dies, wake up other waiting threads.

### DIFF
--- a/native.js
+++ b/native.js
@@ -550,13 +550,28 @@ Native["java/lang/Thread.start0.()V"] = function() {
           { name_index: 9, signature_index: 10 },
           { bytes: "internalExit" },
           { bytes: "()V" },
+          { tag: TAGS.CONSTANT_Methodref, class_index: 12, name_and_type_index: 14 },
+          { tag: TAGS.CONSTANT_Class, name_index: 13 },
+          { bytes: "java/lang/Object" },
+          { name_index: 15, signature_index: 16 },
+          { bytes: "notifyAll" },
+          { bytes: "()V" },
         ]},
       }),
       code: new Uint8Array([
         0x2a,             // aload_0
         0x59,             // dup
-        0xb6, 0x00, 0x01, // invokespecial <idx=1>
-        0xb7, 0x00, 0x07, // invokespecial <idx=7>
+        0xb6, 0x00, 0x01, // invokevitual <idx=1> Thread.run
+        0xb7, 0x00, 0x07, // invokespecial <idx=7> Thread.internalExit
+        0x2a,             // aload_0
+        0x59,             // dup
+        0x4c,             // astore_1
+        0xc2,             // monitorenter
+        0x2a,             // aload_0
+        // Signal waiters waiting on thread
+        0xb7, 0x00, 0x0b, // invokespecial <idx=11> Object.notifyAll
+        0x2b,             // aload_1
+        0xc3,             // monitorexit
         0xb1,             // return
       ])
     });

--- a/tests/java/lang/TestThreadJoin.java
+++ b/tests/java/lang/TestThreadJoin.java
@@ -1,0 +1,25 @@
+package java.lang;
+
+import gnu.testlet.Testlet;
+import gnu.testlet.TestHarness;
+
+public class TestThreadJoin implements Testlet {
+    public int getExpectedPass() { return 1; }
+    public int getExpectedFail() { return 0; }
+    public int getExpectedKnownFail() { return 0; }
+
+    public void test(TestHarness th) {
+        Thread t = new Thread() {
+            public void run() {
+            }
+        };
+        t.start();
+
+        long start = System.currentTimeMillis();
+        try {
+            t.join();
+        } catch (InterruptedException e) {
+        }
+        th.check(System.currentTimeMillis() - start < 500);
+    }
+}


### PR DESCRIPTION
`Thead.join()` is used to wait for  another thread dies. It should return immediately after the target thread dies, but I found 1 second extra delay in some circumstance.

The cause of the delay is that the reference implementation uses `Object.wait()` to wait and check if the thread is alive:
```Java
    public final synchronized void join() throws InterruptedException {
        while (isAlive()) {
            wait(1000);
        }
    }
```

Before terminating the thread, the [reference implementation](https://java.net/projects/phoneme/sources/svn/content/components/cldc/branches/cldc-feature-mr4-active/src/vm/share/runtime/Thread.cpp?rev=20547) will call `Object.notifyAll()` to notify all waiting thread:
```C++
void Thread::finish() {
  ...
  // Signal waiters waiting on thread
  Scheduler::notify(&receiver, true, false JVM_NO_CHECK_AT_BOTTOM);
}
```

But our implementation doesn't do so. So if the thread is dead right after we call `Thread.join()`, we need to wait 1 second until timeout. That's why we has a delay sometimes.

I fix this issue by calling `notifyAll` when the thread gets killed.