### PR TITLE
Support input types of number, tel, email and url

### DIFF
--- a/main.html.in
+++ b/main.html.in
@@ -180,6 +180,10 @@
       <div id="main" role="main">
         <canvas id="canvas"></canvas>
         <input id="password-editor" class="text-editor" type="password">
+        <input id="tel-editor" class="text-editor" type="tel">
+        <input id="number-editor" class="text-editor" type="number">
+        <input id="email-editor" class="text-editor" type="email">
+        <input id="url-editor" class="text-editor" type="url">
         <div id="textarea-editor" class="text-editor" contenteditable="true"></div>
         <!-- The hidden textarea editor is used to measure the content height -->
         <div id="hidden-textarea-editor" class="text-editor"></div>


### PR DESCRIPTION
This makes improvement on the TextField edtior.
It sets correct input type and [x-inputmode](https://bugzilla.mozilla.org/show_bug.cgi?id=796544) to the text field to help type numeric values, phone number, URL and email address with capitalization and suggestion supports.