### PR TITLE
Add method signature in the stacktrace

### DIFF
--- a/interpreter.ts
+++ b/interpreter.ts
@@ -121,7 +121,7 @@ module J2ME {
     var className = ex.klass.classInfo.className;
     var detailMessage = util.fromJavaString(CLASSES.getField(ex.klass.classInfo, "I.detailMessage.Ljava/lang/String;").get(ex));
     return className + ": " + (detailMessage || "") + "\n" + stackTrace.map(function(entry) {
-      return " - " + entry.className + "." + entry.methodName + "(), pc=" + entry.offset;
+      return " - " + entry.className + "." + entry.methodName + entry.methodSignature + ", pc=" + entry.offset;
     }).join("\n") + "\n\n";
   }
 
@@ -161,6 +161,7 @@ module J2ME {
         stackTrace.push({
           className: classInfo.className,
           methodName: frame.methodInfo.name,
+          methodSignature: frame.methodInfo.signature,
           offset: frame.pc
         });
       }

--- a/native.js
+++ b/native.js
@@ -423,7 +423,7 @@ Native["java/lang/Throwable.fillInStackTrace.()V"] = function() {
             return;
         var classInfo = methodInfo.classInfo;
         var className = classInfo.className;
-        this.stackTrace.unshift({ className: className, methodName: methodName, offset: frame.bci });
+        this.stackTrace.unshift({ className: className, methodName: methodName, methodSignature: methodInfo.signature, offset: frame.bci });
     }.bind(this));
 };
 


### PR DESCRIPTION
This makes debugging obfuscated MIDlets easier.