### PR TITLE
Remove obsolete make clean step.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,6 @@ benchmarks: java tests
 	make -C bench
 
 clean:
-	rm -f j2me.js `find . -name "*~"`
 	rm -rf build
 	rm -f config/build.js
 	make -C tools/jasmin-2.4 clean


### PR DESCRIPTION
We no longer have a j2me.js file in the root directory and as far as I can tell nothing generates files with a `~`.

make clean keeps failing for me since I use `~` to keep folders in git repos that are globally ignored.  