### PR TITLE
correctly initialize primitive array classes

### DIFF
--- a/vm/classRegistry.ts
+++ b/vm/classRegistry.ts
@@ -89,7 +89,7 @@ module J2ME {
       // Link primitive arrays.
       PrimitiveArrayClassInfo.initialize();
       for (var i = 0; i < primitiveTypes.length; i++) {
-        this.getClass("[" + typeName);
+        this.getClass("[" + primitiveTypes[i]);
       }
       leaveTimeline("initializeBuiltinClasses");
     }


### PR DESCRIPTION
The bug doesn't break anything, as far as I know, but we aren't initializing primitive array classes when we think we are, because we reference *typeName* during every iteration of the loop, but we don't set it for each iteration. Since we only dereference *primitiveTypes[i]* once, I just inlined it.
