### PR TITLE
shush jar creation

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -4,7 +4,7 @@ benchmark.jar: $(SRCS) ../java/classes.jar ../tests/tests.jar
 	rm -rf build
 	mkdir build
 	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar:../tests/tests.jar -extdirs "" -d ./build $(SRCS) > /dev/null
-	cd build && jar cvf0 ../benchmark.jar *
+	cd build && jar cf0 ../benchmark.jar *
 	rm -rf build
 
 ../java/classes.jar:

--- a/java/Makefile
+++ b/java/Makefile
@@ -26,8 +26,8 @@ classes.jar: $(SRCS) $(JPP_DESTS)
 	$(foreach dir,$(SRC_DIRS),cp -a $(dir)/. build-src/;)
 	find ./build-src -name *.java > build-srcs.txt
 	javac -cp build-src -g:none -source 1.3 -target 1.3 -bootclasspath "" -extdirs "" -d ./build @build-srcs.txt > /dev/null
-	cd build && jar cvf0 ../classes.jar *
-	jar uvf0 classes.jar $(EXTRA)
+	cd build && jar cf0 ../classes.jar *
+	jar uf0 classes.jar $(EXTRA)
 	rm -rf build build-src
 
 tools/Jpp.class: tools/Jpp.java

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -64,11 +64,11 @@ tests.jar: $(SRCS) $(JASMIN_SRCS) Testlets.java
 	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar -cp $(BUILDTIME_SUPPORT_DIR) -extdirs "" -d ./build $(SRCS) > /dev/null
 	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar -extdirs "" -d ./build $(RUNTIME_SUPPORT_SRCS) > /dev/null
 	java -jar ../tools/jasmin-2.4/jasmin.jar -d build/ $(JASMIN_SRCS)
-	jar cvfe tests.jar RunTests -C build/ .
-	jar uvf $(PACKAGE_FILES) > /dev/null
+	jar cfe tests.jar RunTests -C build/ .
+	jar uf $(PACKAGE_FILES) > /dev/null
 	# Create JARs for JARStore tests
-	jar cvf compressed.jar build/RunTests.class
-	jar cvf0 uncompressed.jar build/RunTests.class
+	jar cf compressed.jar build/RunTests.class
+	jar cf0 uncompressed.jar build/RunTests.class
 	rm -rf build
 
 clean:


### PR DESCRIPTION
@marco-c's #1228 pushed us over the 10k log line limit on Travis again (which we re-approached with @TimAbraldes's #1209), so this change shushes JAR creation, as @brendandahl suggested in https://github.com/mozilla/j2me.js/pull/1209#issuecomment-78088971, to get us back under it.
