### PR TITLE
Don't copy the array passed to util.decodeUtf8

### DIFF
--- a/util.js
+++ b/util.js
@@ -6,8 +6,8 @@
 var util = (function () {
   var Utf8TextDecoder = new TextDecoder("utf-8");
 
-  function decodeUtf8(arrayBuffer) {
-    return Utf8TextDecoder.decode(new Uint8Array(arrayBuffer));
+  function decodeUtf8(array) {
+    return Utf8TextDecoder.decode(array);
   }
 
   /**


### PR DESCRIPTION
All the util.decodeUtf8 callers are calling it with a TypedArray parameter, so we're copying the ArrayBuffer contents before decoding.