### PR TITLE
Create ZIP buffers with the correct size right from the beginning

### DIFF
--- a/libs/jarstore.js
+++ b/libs/jarstore.js
@@ -5,8 +5,9 @@
 
 var JARStore = (function() {
   var DATABASE = "JARStore";
-  var VERSION = 1;
-  var OBJECT_STORE = "files";
+  var VERSION = 2;
+  var OBJECT_STORE_OLD = "files";
+  var OBJECT_STORE_WITH_UNCOMPRESSED_LEN = "files_v2"
   var KEY_PATH = "jarName";
 
   var database;
@@ -15,7 +16,14 @@ var JARStore = (function() {
 
   var upgrade = {
     "0to1": function(database, transaction, next) {
-      database.createObjectStore(OBJECT_STORE, { keyPath: KEY_PATH });
+      database.createObjectStore(OBJECT_STORE_OLD, { keyPath: KEY_PATH });
+      next();
+    },
+    "1to2": function(database, transaction, next) {
+      database.deleteObjectStore(OBJECT_STORE_OLD);
+      // We don't migrate data from the old format to the new one, but
+      // rely on JARStore users to recreate the needed data.
+      database.createObjectStore(OBJECT_STORE_WITH_UNCOMPRESSED_LEN, { keyPath: KEY_PATH });
       next();
     },
   };
@@ -60,8 +68,8 @@ var JARStore = (function() {
       return new Promise(function(resolve, reject) {
         var zip = new ZipFile(jarData, true);
 
-        var transaction = database.transaction(OBJECT_STORE, "readwrite");
-        var objectStore = transaction.objectStore(OBJECT_STORE);
+        var transaction = database.transaction(OBJECT_STORE_WITH_UNCOMPRESSED_LEN, "readwrite");
+        var objectStore = transaction.objectStore(OBJECT_STORE_WITH_UNCOMPRESSED_LEN);
         var request = objectStore.put({
           jarName: jarName,
           jar: zip.directory,
@@ -87,8 +95,8 @@ var JARStore = (function() {
   function loadJAR(jarName) {
     return openDatabase.then(function() {
       return new Promise(function(resolve, reject) {
-        var transaction = database.transaction(OBJECT_STORE, "readonly");
-        var objectStore = transaction.objectStore(OBJECT_STORE);
+        var transaction = database.transaction(OBJECT_STORE_WITH_UNCOMPRESSED_LEN, "readonly");
+        var objectStore = transaction.objectStore(OBJECT_STORE_WITH_UNCOMPRESSED_LEN);
         var request = objectStore.get(jarName);
 
         request.onerror = function() {
@@ -163,8 +171,8 @@ var JARStore = (function() {
       return new Promise(function(resolve, reject) {
         jars.clear();
 
-        var transaction = database.transaction(OBJECT_STORE, "readwrite");
-        var objectStore = transaction.objectStore(OBJECT_STORE);
+        var transaction = database.transaction(OBJECT_STORE_WITH_UNCOMPRESSED_LEN, "readwrite");
+        var objectStore = transaction.objectStore(OBJECT_STORE_WITH_UNCOMPRESSED_LEN);
         var request = objectStore.clear();
 
         request.onerror = function() {

--- a/libs/jarstore.js
+++ b/libs/jarstore.js
@@ -132,7 +132,7 @@ var JARStore = (function() {
     if (entry.compression_method === 0) {
       bytes = entry.compressed_data;
     } else if (entry.compression_method === 8) {
-      bytes = inflate(entry.compressed_data);
+      bytes = inflate(entry.compressed_data, entry.uncompressed_len);
     } else {
       return null;
     }

--- a/libs/zipfile.js
+++ b/libs/zipfile.js
@@ -95,7 +95,7 @@ var fixedDistCodeTab = [new Int32Array([
   0x50003, 0x50013, 0x5000b, 0x5001b, 0x50007, 0x50017, 0x5000f, 0x00000
 ]), 5];
 
-function inflate(bytes) {
+function inflate(bytes, uncompressed_len) {
   var bytesPos = 0;
 
   var codeSize = 0;
@@ -171,21 +171,8 @@ function inflate(bytes) {
     return [codes, maxLen];
   };
 
-  var buffer;
+  var buffer = new Uint8Array(uncompressed_len);
   var bufferLength = 0;
-
-  function ensureBuffer(requested) {
-    var current = buffer ? buffer.byteLength : 0;
-    if (requested <= current)
-      return;
-    var size = 512;
-    while (size < requested)
-      size <<= 1;
-    var buffer2 = new Uint8Array(size);
-    for (var i = 0; i < current; ++i)
-      buffer2[i] = buffer[i];
-    buffer = buffer2;
-  }
 
   function readBlock() {
     var eof = false;
@@ -217,17 +204,12 @@ function inflate(bytes) {
       codeBuf = 0;
       codeSize = 0;
 
-      ensureBuffer(bufferLength + blockLen);
       var end = bufferLength + blockLen;
-      for (var n = bufferLength; n < end; ++n) {
-        if (typeof (b = bytes[bytesPos++]) == 'undefined') {
-          eof = true;
-          break;
-        }
-        buffer[n] = b;
+      for (; bufferLength < end && bytesPos < bytes.length; ++bufferLength, ++bytesPos) {
+        buffer[bufferLength] = bytes[bytesPos];
       }
-      bufferLength = end;
-      return eof;
+
+      return bytesPos === bytes.length;
     }
 
     var litCodeTable;
@@ -276,20 +258,13 @@ function inflate(bytes) {
       new Error('Unknown block type in flate stream');
     }
 
-    var limit = buffer ? buffer.length : 0;
-    var pos = bufferLength;
     while (true) {
       var code1 = getCode(litCodeTable);
       if (code1 < 256) {
-        if (pos + 1 >= limit) {
-          ensureBuffer(pos + 1);
-          limit = buffer.length;
-        }
-        buffer[pos++] = code1;
+        buffer[bufferLength++] = code1;
         continue;
       }
       if (code1 == 256) {
-        bufferLength = pos;
         return eof;
       }
       code1 -= 257;
@@ -304,30 +279,15 @@ function inflate(bytes) {
       if (code2 > 0)
         code2 = getBits(code2);
       var dist = (code1 & 0xffff) + code2;
-      if (pos + len >= limit) {
-        ensureBuffer(pos + len);
-        limit = buffer.length;
-      }
-      for (var k = 0; k < len; ++k, ++pos)
-        buffer[pos] = buffer[pos - dist];
+      for (var k = 0; k < len; ++k, ++bufferLength)
+        buffer[bufferLength] = buffer[bufferLength - dist];
     }
   };
 
   while (!readBlock())
     ;
 
-  // Shrink the buffer to the actual data size.
-
-  // If we've got more than 10% slack, copy the buffer. If that is a perf problem,
-  // adjust the slack. If that's a memory problem then adjust the growth heuristic
-  // of the buffer. At the moment it's 2x, perhaps 1.5x would be a better growth
-  // factor.
-  if (bufferLength / buffer.length < 0.9) {
-    var result = new Uint8Array(bufferLength);
-    result.set(buffer.subarray(0, bufferLength), 0);
-    return result;
-  }
-  return new Uint8Array(buffer.buffer, 0, bufferLength);
+  return buffer;
 }
 
 var arrays = J2ME.ArrayUtilities.makeArrays(256);
@@ -375,11 +335,10 @@ function ZipFile(buffer, extract) {
       arrays = J2ME.ArrayUtilities.makeArrays(filename_len);
     }
     var array = arrays[filename_len];
-    var filename = "";
     for (var n = 0; n < filename_len; ++n) {
       array[n] = String.fromCharCode(bytes[pos++]);
     }
-    filename = array.join("");
+    var filename = array.join("");
     // locate the compressed data
     var local_extra_len = view.getInt16(local_header_offset + 28, true);
     var data_offset = local_header_offset + 30 + filename_len + local_extra_len;
@@ -397,6 +356,7 @@ function ZipFile(buffer, extract) {
     directory[filename] = {
       compression_method: compression_method,
       compressed_data: compressed_data,
+      uncompressed_len: uncompressed_len,
     };
     // advance to the next entry
     pos += extra_len + comment_len;
@@ -417,7 +377,7 @@ ZipFile.prototype = {
     case 0: // stored
       return data;
     case 8: // deflated
-      return inflate(data);
+      return inflate(data, entry.uncompressed_len);
     }
     return null;
   }


### PR DESCRIPTION
The upgrade step is just deleting the old object store and creating a new one (main.js will then re-download the MIDlet JAR).
It'd be complex to migrate the old data to the new format with the *uncompressed_len* property (well, it wouldn't be difficult, but it would require either writing a new function similar to *inflate* or modifying *inflate* to work for buffers with an unknown length, so I think handling it this way is much cleaner).