### PR TITLE
Change executeFrames to only execute one frame.

### DIFF
--- a/native.js
+++ b/native.js
@@ -288,7 +288,7 @@ Native["java/lang/Class.invoke_clinit.()V"] = function() {
     var className = classInfo.getClassNameSlow();
     var clinit = classInfo.staticInitializer;
     if (clinit && clinit.classInfo.getClassNameSlow() === className) {
-        $.ctx.executeFrames([Frame.create(clinit, [], 0)]);
+        $.ctx.executeFrame(Frame.create(clinit, [], 0));
     }
 };
 

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -414,13 +414,9 @@ module J2ME {
       release || assert (Frame.isMarker(marker));
     }
 
-    executeFrames(group: Frame []) {
+    executeFrame(frame: Frame) {
       var frames = this.frames;
-      frames.push(Frame.Marker);
-
-      for (var i = 0; i < group.length; i++) {
-        frames.push(group[i]);
-      }
+      frames.push(Frame.Marker, frame);
 
       try {
         var returnValue = VM.execute();

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1280,7 +1280,7 @@ module J2ME {
         for (var i = 0; i < slots; i++) {
           frame.setLocal(j++, arguments[i]);
         }
-        return $.ctx.executeFrames([frame]);
+        return $.ctx.executeFrame(frame);
       };
       (<any>method).methodInfo = methodInfo;
       return method;
@@ -1313,7 +1313,7 @@ module J2ME {
           return;
         }
       }
-      return $.ctx.executeFrames([frame]);
+      return $.ctx.executeFrame(frame);
     };
     (<any>method).methodInfo = methodInfo;
     return method;


### PR DESCRIPTION
We don't currently execute more than one frame at a time in executeFrames. This gets rid of the array allocation.