### PR TITLE
only force collectors if without security

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -214,7 +214,9 @@ var Benchmark = (function() {
       var self = this;
       var done = storage.round >= storage.numRounds;
       function run() {
-        forceCollectors();
+        if (NO_SECURITY) {
+          forceCollectors();
+        }
         if (storage.round !== 0) {
           if (NO_SECURITY) {
             self.sampleMemory();


### PR DESCRIPTION
Benchmarking currently fails if you haven't disabled security, since there are two calls to *forceCollectors*, which escalates privileges, and only one of them ensures that security is disabled first. Here's the obvious fix.
