### PR TITLE
extend wait timeout for tests

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -16,7 +16,7 @@ casper.on('remote.message', function(message) {
     this.echo(message);
 });
 
-casper.options.waitTimeout = 70000;
+casper.options.waitTimeout = 90000;
 casper.options.verbose = true;
 casper.options.logLevel = "debug";
 casper.options.viewportSize = { width: 240, height: 320 };

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -16,7 +16,7 @@ casper.on('remote.message', function(message) {
     this.echo(message);
 });
 
-casper.options.waitTimeout = 90000;
+casper.options.waitTimeout = 80000;
 casper.options.verbose = true;
 casper.options.logLevel = "debug";
 casper.options.viewportSize = { width: 240, height: 320 };


### PR DESCRIPTION
The "basic tests" take 60+ seconds to run now that we've added more tests, and we previously set CasperJS's *waitTimeout* to 70 seconds, so tests time out sometimes. We should increase the timeout to provide more cushion for test anomalies. This PR sets it to 90 seconds.

On the other hand: the less cushion, the more likely we are to notice perf regressions that make the tests run longer, like the one I found in #1273. So I'm a bit ambivalent about this change. If we take it, we should make sure to monitor test run times closely. Ideally, we'd graph them over time.
