### PR TITLE
rename build/ directory to bld/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ certs/j2se_main.ks
 certs/j2se_test.ks
 tests/Testlets.java
 output/
-build/
+bld/
 build_tools/
 .checksum
 java/build-src/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all test tests j2me java certs app clean jasmin aot shumway config-build benchmarks
-BASIC_SRCS=$(shell find . -maxdepth 2 -name "*.ts" -not -path "./build/*") config.ts
-JIT_SRCS=$(shell find jit -name "*.ts" -not -path "./build/*")
+BASIC_SRCS=$(shell find . -maxdepth 2 -name "*.ts" -not -path "./bld/*") config.ts
+JIT_SRCS=$(shell find jit -name "*.ts" -not -path "./bld/*")
 SHUMWAY_SRCS=$(shell find shumway -name "*.ts")
 RELEASE ?= 0
 VERSION ?=$(shell date +%s)
@@ -94,43 +94,43 @@ jasmin:
 relooper:
 	make -C jit/relooper/
 
-build/j2me.js: $(BASIC_SRCS) $(JIT_SRCS)
+bld/j2me.js: $(BASIC_SRCS) $(JIT_SRCS)
 	@echo "Building J2ME"
-	node tools/tsc.js --sourcemap --target ES5 references.ts -d --out build/j2me.js
+	node tools/tsc.js --sourcemap --target ES5 references.ts -d --out bld/j2me.js
 
-build/j2me-jsc.js: $(BASIC_SRCS) $(JIT_SRCS)
+bld/j2me-jsc.js: $(BASIC_SRCS) $(JIT_SRCS)
 	@echo "Building J2ME AOT Compiler"
-	node tools/tsc.js --sourcemap --target ES5 references-jsc.ts -d --out build/j2me-jsc.js
+	node tools/tsc.js --sourcemap --target ES5 references-jsc.ts -d --out bld/j2me-jsc.js
 
-build/jsc.js: jsc.ts build/j2me-jsc.js
+bld/jsc.js: jsc.ts bld/j2me-jsc.js
 	@echo "Building J2ME JSC CLI"
-	node tools/tsc.js --sourcemap --target ES5 jsc.ts --out build/jsc.js
+	node tools/tsc.js --sourcemap --target ES5 jsc.ts --out bld/jsc.js
 
-j2me: build/j2me.js build/jsc.js
+j2me: bld/j2me.js bld/jsc.js
 
-aot: build/classes.jar.js
-build/classes.jar.js: java/classes.jar build/jsc.js aot-methods.txt
+aot: bld/classes.jar.js
+bld/classes.jar.js: java/classes.jar bld/jsc.js aot-methods.txt
 	@echo "Compiling ..."
-	js build/jsc.js -cp java/classes.jar -d -jf java/classes.jar -mff aot-methods.txt > build/classes.jar.js
+	js bld/jsc.js -cp java/classes.jar -d -jf java/classes.jar -mff aot-methods.txt > bld/classes.jar.js
 
-build/tests.jar.js: tests/tests.jar build/jsc.js aot-methods.txt
-	js build/jsc.js -cp java/classes.jar tests/tests.jar -d -jf tests/tests.jar -mff aot-methods.txt > build/tests.jar.js
+bld/tests.jar.js: tests/tests.jar bld/jsc.js aot-methods.txt
+	js bld/jsc.js -cp java/classes.jar tests/tests.jar -d -jf tests/tests.jar -mff aot-methods.txt > bld/tests.jar.js
 
-build/program.jar.js: program.jar build/jsc.js aot-methods.txt
-	js build/jsc.js -cp java/classes.jar program.jar -d -jf program.jar -mff aot-methods.txt > build/program.jar.js
+bld/program.jar.js: program.jar bld/jsc.js aot-methods.txt
+	js bld/jsc.js -cp java/classes.jar program.jar -d -jf program.jar -mff aot-methods.txt > bld/program.jar.js
 
 tools/closure.jar:
 	wget -O $@ https://github.com/mykmelez/closure-compiler/releases/download/v0.1/closure.jar
 
-closure: build/classes.jar.js build/j2me.js tools/closure.jar
-	java -jar tools/closure.jar --language_in ECMASCRIPT5 -O J2ME_OPTIMIZATIONS build/j2me.js > build/j2me.cc.js \
-		&& mv build/j2me.cc.js build/j2me.js
-	java -jar tools/closure.jar --language_in ECMASCRIPT5 -O SIMPLE build/classes.jar.js > build/classes.jar.cc.js \
-		&& mv build/classes.jar.cc.js build/classes.jar.js
+closure: bld/classes.jar.js bld/j2me.js tools/closure.jar
+	java -jar tools/closure.jar --language_in ECMASCRIPT5 -O J2ME_OPTIMIZATIONS bld/j2me.js > bld/j2me.cc.js \
+		&& mv bld/j2me.cc.js bld/j2me.js
+	java -jar tools/closure.jar --language_in ECMASCRIPT5 -O SIMPLE bld/classes.jar.js > bld/classes.jar.cc.js \
+		&& mv bld/classes.jar.cc.js bld/classes.jar.js
 
-shumway: build/shumway.js
-build/shumway.js: $(SHUMWAY_SRCS)
-	node tools/tsc.js --sourcemap --target ES5 shumway/references.ts --out build/shumway.js
+shumway: bld/shumway.js
+bld/shumway.js: $(SHUMWAY_SRCS)
+	node tools/tsc.js --sourcemap --target ES5 shumway/references.ts --out bld/shumway.js
 
 # We should update config/build.js everytime to generate the new VERSION number
 # based on current time.

--- a/jsc.ts
+++ b/jsc.ts
@@ -1,4 +1,4 @@
-///<reference path='build/j2me-jsc.d.ts' />
+///<reference path='bld/j2me-jsc.d.ts' />
 
 var jsGlobal = (function() { return this || (1, eval)('this'); })();
 
@@ -84,7 +84,7 @@ module J2ME {
     }
   }
 
-  loadFiles("libs/long.js", "blackBox.js", "build/j2me-jsc.js", "libs/zipfile.js", "libs/jarstore.js", "libs/encoding.js", "util.js");
+  loadFiles("libs/long.js", "blackBox.js", "bld/j2me-jsc.js", "libs/zipfile.js", "libs/jarstore.js", "libs/encoding.js", "util.js");
 
   phase = ExecutionPhase.Compiler;
 

--- a/jsshell.js
+++ b/jsshell.js
@@ -112,18 +112,18 @@ var profileTimeline = false;
 
 try {
   if (profileTimeline) {
-    load("build/shumway.js");
+    load("bld/shumway.js");
   }
-  load("libs/relooper.js", "build/j2me.js","libs/zipfile.js", "blackBox.js",
+  load("libs/relooper.js", "bld/j2me.js","libs/zipfile.js", "blackBox.js",
     "libs/encoding.js", "util.js", "libs/jarstore.js",
     "override.js", "native.js", "string.js", "tests/override.js",
     "midp/midp.js", "midp/gestures.js",
     "libs/long.js", "midp/crypto.js", "libs/forge/md5.js", "libs/forge/util.js",
-    "build/classes.jar.js");
+    "bld/classes.jar.js");
 
-  // load("build/classes.jar.js");
-  // load("build/program.jar.js");
-  // load("build/tests.jar.js");
+  // load("bld/classes.jar.js");
+  // load("bld/program.jar.js");
+  // load("bld/tests.jar.js");
 
   var dump = putstr;
 

--- a/main.html.in
+++ b/main.html.in
@@ -19,7 +19,7 @@
   <script type="text/javascript" src="libs/ttest.js" defer></script>
   <!-- #endif -->
   <!-- #if PROFILE > 0 -->
-  <script type="text/javascript" src="build/shumway.js" defer></script>
+  <script type="text/javascript" src="bld/shumway.js" defer></script>
   <!-- #endif -->
   <!--<script type="text/javascript" src="libs/terminal.js" defer></script>-->
   <script type="text/javascript" src="libs/console.js" defer></script>
@@ -39,7 +39,7 @@
 
   <script type="text/javascript" src="libs/compiled-method-cache.js" defer></script>
   <script type="text/javascript" src="libs/relooper.js" defer></script>
-  <script type="text/javascript" src="build/j2me.js" defer></script>
+  <script type="text/javascript" src="bld/j2me.js" defer></script>
   <script type="text/javascript" src="override.js" defer></script>
   <script type="text/javascript" src="native.js" defer></script>
   <script type="text/javascript" src="string.js" defer></script>
@@ -83,9 +83,9 @@
   <script type="text/javascript" src="game-ui.js" defer></script>
 
   <!-- run make aot to generate these -->
-  <script type="text/javascript" src="build/classes.jar.js" defer></script>
-  <!--<script type="text/javascript" src="build/program.jar.js" defer></script>-->
-  <!--<script type="text/javascript" src="build/tests.jar.js" defer></script>-->
+  <script type="text/javascript" src="bld/classes.jar.js" defer></script>
+  <!--<script type="text/javascript" src="bld/program.jar.js" defer></script>-->
+  <!--<script type="text/javascript" src="bld/tests.jar.js" defer></script>-->
   <script type="text/javascript" src="main.js" defer></script>
 </head>
 

--- a/tests/jarstore/jarstoretests.html
+++ b/tests/jarstore/jarstoretests.html
@@ -7,7 +7,7 @@
   <script type="text/javascript" src="../../polyfill/IndexedDB-getAll-shim.js" defer></script>
   <script type="text/javascript" src="../../libs/jarstore.js" defer></script>
   <script type="text/javascript" src="../../libs/promise-6.0.0.js" defer></script>
-  <script type="text/javascript" src="../../build/j2me.js" defer></script>
+  <script type="text/javascript" src="../../bld/j2me.js" defer></script>
   <script type="text/javascript" src="../../libs/zipfile.js" defer></script>
   <script type="text/javascript" src="../../libs/load.js" defer></script>
   <script type="text/javascript" src="jarstoretests.js" defer></script>

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -11,9 +11,9 @@ mkdir $PACKAGE_DIR/build
 
 # setup the root
 cp *.js *.html *.webapp $PACKAGE_DIR/.
-cp build/j2me.js $PACKAGE_DIR/build/.
-cp build/shumway.js $PACKAGE_DIR/build/.
-cp build/classes.jar.js $PACKAGE_DIR/build/.
+cp bld/j2me.js $PACKAGE_DIR/bld/.
+cp bld/shumway.js $PACKAGE_DIR/bld/.
+cp bld/classes.jar.js $PACKAGE_DIR/bld/.
 
 # copy over jars/jads that are used for the webapp
 # NB: we could be smart about this and parse the manifest, patches welcome!

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -7,7 +7,7 @@ PACKAGE_DIR="output"
 
 rm -rf $PACKAGE_DIR/
 mkdir $PACKAGE_DIR
-mkdir $PACKAGE_DIR/build
+mkdir $PACKAGE_DIR/bld
 
 # setup the root
 cp *.js *.html *.webapp $PACKAGE_DIR/.


### PR DESCRIPTION
This renames the build/ directory to bld/ so it won't get stripped by Gaia when j2me.js is installed onto a device via Gaia's outoftree_apps/ directory.

@mbebenita asked that we continue to build into a subdirectory (regardless of the name) to make it easier for his editor to exclude build products.

cc: @DouglasSherk so he's aware of the change.
