### PR TITLE
push memory value onto array

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -218,7 +218,7 @@ var Benchmark = (function() {
     sampleMemoryToStorage: function() {
       var mem = sampleMemory();
       for (var p in mem) {
-        storage.current[p] = mem[p];
+        storage.current[p].push(mem[p]);
       }
       saveStorage();
     },


### PR DESCRIPTION
Fix bustage in the benchmark code by pushing memory value onto array of values instead of overwriting array with value.