### PR TITLE
Avoid creating intermediate strings when generating CSS color values.

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -492,7 +492,7 @@ var currentlyFocusedTextEditor;
         var b = (pixel >> 16) & 0xff;
         var g = (pixel >> 8) & 0xff;
         var r = pixel & 0xff;
-        var style = "rgba(" + r + "," + g + "," + b + "," + 1 + ")";
+        var style = util.rgbaToCSS(r, g, b, 1);
         c.fillStyle = c.strokeStyle = style;
     }
 

--- a/util.js
+++ b/util.js
@@ -126,12 +126,24 @@ var util = (function () {
     return chars;
   }
 
+  // rgbaToCSS() can be called frequently. Using |rgbaBuf| avoids creating
+  // many intermediate strings.
+  var rgbaBuf = ["rgba(", 0, ",", 0, ",", 0, ",", 0, ")"];
+
+  function rgbaToCSS(r, g, b, a) {
+    rgbaBuf[1] = r;
+    rgbaBuf[3] = g;
+    rgbaBuf[5] = b;
+    rgbaBuf[7] = a;
+    return rgbaBuf.join('');
+  }
+
   function abgrIntToCSS(pixel) {
     var a = (pixel >> 24) & 0xff;
     var b = (pixel >> 16) & 0xff;
     var g = (pixel >> 8) & 0xff;
     var r = pixel & 0xff;
-    return "rgba(" + r + "," + g + "," + b + "," + (a/255) + ")";
+    return rgbaToCSS(r, g, b, a/255);
   }
 
   return {
@@ -147,6 +159,7 @@ var util = (function () {
     compareTypedArrays: compareTypedArrays,
     pad: pad,
     toCodePointArray: toCodePointArray,
+    rgbaToCSS: rgbaToCSS,
     abgrIntToCSS: abgrIntToCSS,
   };
 })();


### PR DESCRIPTION
This avoids creating 10s of MiB of garbage strings when running the
asteroids midlet for a moderate period.