### PR TITLE
Reuse the stack array in Frame.reset().

### DIFF
--- a/vm/context.ts
+++ b/vm/context.ts
@@ -100,6 +100,7 @@ module J2ME {
 
     constructor(methodInfo: MethodInfo, local: any [], localBase: number) {
       frameCount ++;
+      this.stack = [];
       this.reset(methodInfo, local, localBase);
     }
 
@@ -109,7 +110,7 @@ module J2ME {
       this.code = methodInfo ? methodInfo.codeAttribute.code : null;
       this.pc = 0;
       this.opPC = 0;
-      this.stack = [];
+      this.stack.length = 0;
       this.local = local;
       this.localBase = localBase;
       this.lockObject = null;


### PR DESCRIPTION
Zeroing the length has the same effect as assigning a new array but
avoids the creation of that new array. This avoids 10s of MiBs of
allocations when running the asteroids midlet for a while.