### PR TITLE
Use minimize memory approach and gc in new page between rounds.

### DIFF
--- a/gc.html
+++ b/gc.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <script type="text/javascript" src="benchmark.js"></script>
+  <script type="text/javascript" src="gc.js"></script>
+</head>
+
+<body>
+</body>
+</html>

--- a/gc.js
+++ b/gc.js
@@ -1,0 +1,3 @@
+Benchmark.forceCollectors().then(function() {
+  window.location = window.location.href.replace("gc.html", "index.html");
+});

--- a/index.js.in
+++ b/index.js.in
@@ -721,6 +721,12 @@ DumbPipe.registerOpener("windowOpen", function(message, sender) {
   window.open(message);
 });
 
+// #if BENCHMARK == "true"
+DumbPipe.registerOpener("gcReload", function(message, sender) {
+  window.location = window.location.href.replace("index.html", "gc.html");
+});
+// #endif
+
 DumbPipe.registerOpener("reload", function(message, sender) {
   window.location.reload();
 });

--- a/jit/analyze.ts
+++ b/jit/analyze.ts
@@ -74,6 +74,7 @@ module J2ME {
     "gnu/testlet/vm/NativeTest.returnAfterPause.()I": YieldReason.Root,
     "gnu/testlet/vm/NativeTest.dumbPipe.()Z": YieldReason.Root,
     "gnu/testlet/TestHarness.getNumDifferingPixels.(Ljava/lang/String;)I": YieldReason.Root,
+    "org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V": YieldReason.Root,
   };
 
   export var yieldVirtualMap = {

--- a/tests/native.js
+++ b/tests/native.js
@@ -166,13 +166,14 @@ MIDP.fsRoots.push("/");
 
 Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = function(label) {
   if (typeof Benchmark !== "undefined") {
-    var memory = Benchmark.sampleMemory();
-    var keys = ["totalSize", "domSize", "styleSize", "jsObjectsSize", "jsStringsSize", "jsOtherSize", "otherSize"];
-    var rows = [];
-    rows.push(keys);
-    rows.push(keys.map(function(k) { return memory[k] }));
-    var RIGHT = Benchmark.RIGHT;
-    var alignment = [RIGHT, RIGHT, RIGHT, RIGHT, RIGHT, RIGHT, RIGHT];
-    console.log((J2ME.fromJavaString(label) || "Memory sample") + ":\n" + Benchmark.prettyTable(rows, alignment));
+    asyncImpl("V", Benchmark.sampleMemory().then(function(memory) {
+      var keys = ["totalSize", "domSize", "styleSize", "jsObjectsSize", "jsStringsSize", "jsOtherSize", "otherSize"];
+      var rows = [];
+      rows.push(keys);
+      rows.push(keys.map(function(k) { return memory[k] }));
+      var RIGHT = Benchmark.RIGHT;
+      var alignment = [RIGHT, RIGHT, RIGHT, RIGHT, RIGHT, RIGHT, RIGHT];
+      console.log((J2ME.fromJavaString(label) || "Memory sample") + ":\n" + Benchmark.prettyTable(rows, alignment));
+    }));
   }
 };


### PR DESCRIPTION
I've copied what the minimize memory usage button in about:memory does. Gives much more consistent results on device.  Desktop is also more consistent but whipsaws more.

![flame _totalsize](https://cloud.githubusercontent.com/assets/942640/6832970/f7ae91c8-d2e6-11e4-9977-037bac5a5c13.png)
![flame _startuptime](https://cloud.githubusercontent.com/assets/942640/6832969/f7ab9036-d2e6-11e4-82b3-aa9e6f7edf78.png)

![desktop _totalsize](https://cloud.githubusercontent.com/assets/942640/6832987/0f7a42f2-d2e7-11e4-9b7c-899d2a90a76c.png)
![desktop _startuptime](https://cloud.githubusercontent.com/assets/942640/6832986/0f79c462-d2e7-11e4-8f0b-2b305808bb67.png)
Above: There's a spike on the new way, but I seem to have got a bit unlucky on this round because I have only seen that once in many runs.

Below: Running the new code but with a 1mb allocation in main.js.
![desktop 1mb _totalsize](https://cloud.githubusercontent.com/assets/942640/6833007/273e0f5e-d2e7-11e4-835f-4085be71f2b0.png)
![desktop 1mb _startuptime](https://cloud.githubusercontent.com/assets/942640/6833006/273ad424-d2e7-11e4-9db7-8b1236eeef66.png)



