### PR TITLE
Remove unused `Graphics` methods

### DIFF
--- a/java/custom/javax/microedition/lcdui/Graphics.java
+++ b/java/custom/javax/microedition/lcdui/Graphics.java
@@ -1469,27 +1469,6 @@ public class Graphics {
     native void resetGC();
 
     /**
-     * Preserve MIDP runtime GC.
-     * - Our internal MIDP clip to protect 
-     * it from MIDlet drawing on top of our widget.
-     * - Translation
-     *
-     * @param systemX The system upper left x coordinate
-     * @param systemY The system upper left y coordinate
-     * @param systemW The system width of the rectangle
-     * @param systemH The system height of the rectangle
-     */
-    native void preserveMIDPRuntimeGC(int systemX, int systemY, int systemW, int systemH);
-
-    /**
-     * Restore the runtime GC.
-     * - Release the internal runtime clip values by
-     * unsetting the variable.
-     * - Restore the original translation
-     */
-    native void restoreMIDPRuntimeGC();
-
-    /**
      * Renders provided Image onto this Graphics object.
      *
      * @param img the Image to be rendered

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -558,12 +558,6 @@ var currentlyFocusedTextEditor;
         return swapRB(rgb) | 0xff000000;
     }
 
-
-    Native["javax/microedition/lcdui/Graphics.restoreMIDPRuntimeGC.()V"] = function() {
-        this.runtimeClipEnforce = false;
-        translate(this, this.aX-this.transX, this.aY-this.transY);
-    };
-
     Native["javax/microedition/lcdui/Graphics.resetGC.()V"] = function() {
         resetGC(this);
     };
@@ -856,13 +850,6 @@ var currentlyFocusedTextEditor;
         var newY1 = Math.max(0, y) & 0x7fff;
         var newY2 = Math.min(g.maxHeight, y + height) & 0x7fff;
 
-        if (g.runtimeClipEnforce) {
-            newX1 = Math.max(newX1, g.systemClipX1);
-            newY1 = Math.max(newY1, g.systemClipY1);
-            newX2 = Math.min(newX2, g.systemClipX2);
-            newY2 = Math.min(newY2, g.systemClipY2);
-        }
-
         if (width <= 0 || height <= 0 || newX2 <= newX1 || newY2 <= newY1) {
             newX1 = newY1 = newX2 = newY2 = 0;
         }
@@ -909,12 +896,6 @@ var currentlyFocusedTextEditor;
         this.rgbColor = 0;
         this.gray = 0;
         this.pixel = 0;
-        this.aX = 0;
-        this.aY = 0;
-        this.systemClipX1 = 0;
-        this.systemClipX2 = 0;
-        this.systemClipY1 = 0;
-        this.systemClipY2 = 0;
         this.clipX1 = 0;
         this.clipX2 = 0;
         this.clipY1 = 0;
@@ -1000,23 +981,6 @@ var currentlyFocusedTextEditor;
 
     Native["javax/microedition/lcdui/Graphics.setClip.(IIII)V"] = function(x, y, w, h) {
         setClip(this, x, y, w, h);
-    };
-
-    Native["javax/microedition/lcdui/Graphics.preserveMIDPRuntimeGC.(IIII)V"] = function(systemX, systemY, systemW, systemH) {
-        this.runtimeClipEnforce = true;
-        clipRect(this, systemX, systemY, systemW, systemH);
-
-        // this is the first time, we setup
-        // the systemClip values.
-        this.systemClipX1 = this.clipX1;
-        this.systemClipY1 = this.clipY1;
-        this.systemClipX2 = this.clipX2;
-        this.systemClipY2 = this.clipY2;
-
-        // Preserve the translation system
-        translate(this, systemX, systemY);
-        this.aX = this.transX;
-        this.aY = this.transY;
     };
 
     function drawString(g, str, x, y, anchor, isOpaque) {


### PR DESCRIPTION
`Graphics.preserveMIDPRuntimeGC` and `Graphics.restoreMIDPRuntimeGC` are
package-private to the javax.microedition.lcdui package and are not
consumed by any members of that package. It seems we can safely remove
them from the `Graphics` class.

Note that this removes the declaration as well as the implementation;
any future errors are likely to be compilation failures rather than
runtime issues.