### PR TITLE
make some file writes asynchronous, then optimize them

### DIFF
--- a/java/custom/com/sun/cdc/io/j2me/file/Protocol.java
+++ b/java/custom/com/sun/cdc/io/j2me/file/Protocol.java
@@ -876,7 +876,9 @@ public class Protocol extends ConnectionBaseAdapter implements FileConnection {
      * @throws IOException if the connection is closed
      */
     protected void ensureConnected() throws IOException {
-        connect(fileRoot, filePath + fileName);
+        if (fileHandler == null) {
+            connect(fileRoot, filePath + fileName);
+        }
     }
 
     /**

--- a/jit/analyze.ts
+++ b/jit/analyze.ts
@@ -29,6 +29,7 @@ module J2ME {
     "com/sun/midp/lcdui/DisplayDevice.gainedForeground0.(II)V": YieldReason.Root,
     "com/sun/cdc/io/j2me/file/DefaultFileHandler.openForRead.()V": YieldReason.Root,
     "com/sun/cdc/io/j2me/file/DefaultFileHandler.openForWrite.()V": YieldReason.Root,
+    "com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I": YieldReason.Root,
     "java/lang/Thread.sleep.(J)V": YieldReason.Root,
     "com/sun/cldc/isolate/Isolate.waitStatus.(I)V": YieldReason.Root,
     "com/sun/j2me/location/PlatformLocationProvider.waitForNewLocation.(IJ)Z": YieldReason.Root,

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -602,6 +602,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(b
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.write: ignored file");
         asyncImpl("I", Promise.resolve(len));
+        return;
     }
 
     var fd = this.nativeDescriptor;

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -598,17 +598,22 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(b,
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(b, off, len) {
     var pathname = J2ME.fromJavaString(this.nativePath);
-    DEBUG_FS && console.log("DefaultFileHandler.write: " + pathname);
+    DEBUG_FS && console.log("DefaultFileHandler.write: " + pathname + " " + off + "+" + len);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.write: ignored file");
-        return len;
+        asyncImpl("I", Promise.resolve(len));
     }
 
     var fd = this.nativeDescriptor;
     fs.write(fd, b.subarray(off, off + len));
-    // The "length of data really written," which is always the length requested
-    // in our implementation.
-    return len;
+
+    // The return value is the "length of data really written," which is
+    // always the same as the length requested in our implementation.
+    //
+    // We always write asynchronously to ensure that a thread that writes
+    // a bunch of data doesn't starve a UI thread and reduce responsiveness.
+    //
+    asyncImpl("I", Promise.resolve(len));
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = function(offset) {


### PR DESCRIPTION
https://github.com/mozilla/j2me.js/commit/61f41ee74dac99042aabae9ab74b9c563e6b20bf improves the responsiveness of a particular interaction in a complex midlet by making some file writes asynchronous, so repeated writes on a background thread don't starve the UI thread.

Making the writes asynchronous makes the write operations themselves many times slower (even if the app can do other work in the meantime, so overall app perf doesn't suffer). https://github.com/mozilla/j2me.js/commit/e222f5e2565556941abfb5156b0878811b70cae8 claws back much of that performance by exiting *file/Protocol.ensureConnect* early if *fileHandler* is defined instead of relying on *connect* to do so, which avoids the expensive `filePath + fileName` string concatenation.

(@brendandahl's self-hosting strings branch might also help here, but even if concatenation becomes faster, there's still no need to do it here at all.)

On master, FileConnectionBench averages ~50ms to do these writes. On this branch, it averages ~150ms, so it's still three times slower. But that interaction is much more responsive (although it's still somewhat janky, and this isn't a complete fix).

I expect general runtime speed and responsiveness to improve as well with this fix, although I don't have a good metric for it. Unsure about memory usage, which depends on the cost of StringBuffer.

I didn't expect startup time/memory usage to improve, since I wouldn't expect too much file I/O to happen in the startup path; but I do see some improvement in one test on desktop:

|      Test     | Baseline Mean |   Mean   |   +/-  |    %   |       P       |    Min   |    Max   | 
|:--------------|--------------:|---------:|-------:|-------:|--------------:|---------:|---------:|
| startupTime   |       1,164ms |  1,115ms |  -48ms |  -4.17 |        BETTER |  1,092ms |  1,131ms | 
| totalSize     |      26,681kb | 26,199kb | -482kb |  -1.81 | INSIGNIFICANT | 25,132kb | 26,941kb | 
| domSize       |         152kb |    152kb |    0kb |   0.00 | INSIGNIFICANT |    152kb |    152kb | 
| styleSize     |         412kb |    412kb |    0kb |   0.03 | INSIGNIFICANT |    412kb |    412kb | 
| jsObjectsSize |      16,872kb | 16,799kb |  -72kb |  -0.43 |        BETTER | 16,791kb | 16,806kb | 
| jsStringsSize |         922kb |    629kb | -293kb | -31.80 |        BETTER |    629kb |    629kb | 
| jsOtherSize   |       7,928kb |  7,812kb | -116kb |  -1.47 | INSIGNIFICANT |  6,754kb |  8,548kb | 
| otherSize     |         395kb |    394kb |    0kb |  -0.10 | INSIGNIFICANT |    394kb |    395kb | 
