### PR TITLE
rebuild main-all.js if checksum changes so it respects BENCHMARK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ bld/jsc.js: jsc.ts bld/j2me-jsc.js
 # (and ES5 as the out-language, since Closure doesn't recognize ES6 as a valid
 # out-language) in order for Closure to compile them, even though for now
 # we're optimizing "WHITESPACE_ONLY".
-bld/main-all.js: $(MAIN_JS_SRCS) tools/closure.jar
+bld/main-all.js: $(MAIN_JS_SRCS) tools/closure.jar .checksum
 	java -jar tools/closure.jar --language_in ES6 --language_out ES5 --create_source_map bld/main-all.js.map --source_map_location_mapping "|../" -O WHITESPACE_ONLY $(MAIN_JS_SRCS) > bld/main-all.js
 	echo '//# sourceMappingURL=main-all.js.map' >> bld/main-all.js
 


### PR DESCRIPTION
When *BENCHMARK* changes from `1` to `0`, benchmark.js is removed from the list of *MAIN_ALL_SRCS*, but that doesn't trigger a rebuild for bld/main-all.js, because the remaining files in that list haven't changed (even if the list as a whole has changed).

So *Benchmark* remains defined, which causes main.js to call *Benchmark.initUI*, which tries to access DOM elements that have meanwhile been preprocessed out of main.html, triggering an exception.

The straightforward fix is to make main-all.js depend on .checksum, so it gets rebuilt if *BENCHMARK* (or any other build configuration variable) changes.

(There may be a better fix, unsure. But in any case .checksum is our current state-of-the-art for such dependencies.)
