### PR TITLE
More gfx cleanup

### DIFF
--- a/java/custom/javax/microedition/lcdui/Graphics.java
+++ b/java/custom/javax/microedition/lcdui/Graphics.java
@@ -1434,14 +1434,6 @@ public class Graphics {
     }
 
     /**
-     * Determines if this a <code>Graphics</code> object used to 
-     * represent the device. 
-     * @return true if this Graphics represents the device;
-     *         false - otherwise
-     */
-    native boolean isScreenGraphics();
-
-    /**
      * Reset this Graphics context with the given coordinates
      *
      * @param x1 The upper left x coordinate
@@ -1480,36 +1472,6 @@ public class Graphics {
      * @see Image
      */
     native boolean render(Image img, int x, int y, int anchor);
-
-    /**
-     * Renders the specified region of the provided Image object
-     * onto this Graphics object.
-     *
-     * @param img  the Image object to be rendered
-     * @param x_src the x coordinate of the upper left corner of the region
-     * within the source image to copy
-     * @param y_src the y coordinate of the upper left corner of the region
-     * within the source image to copy
-     * @param width the width of the region to copy
-     * @param height the height of the region to copy
-     * @param transform the desired transformation for the selected region
-     * being copied
-     * @param x_dest the x coordinate of the anchor point in the
-     * destination drawing area
-     * @param y_dest the y coordinate of the anchor point in the
-     * destination drawing area
-     * @param anchor the anchor point for positioning the region within
-     * the destination image
-     *
-     * @return false if <code>src</code> is the same image as the
-     * destination of this <code>Graphics</code> object,
-     * or <code>transform</code> is invalid,
-     * or <code>anchor</code> is invalid,
-     * or the region to be copied exceeds the bounds of the source image.
-     *
-     * @see Image
-     */
-    native boolean renderRegion(Image img, int x_src, int y_src, int width, int height, int transform, int x_dest, int y_dest, int anchor);
 
     /**
      * Returns the maximal width available for the clipping

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -570,10 +570,6 @@ var currentlyFocusedTextEditor;
         reset(this, 0, 0, this.maxWidth, this.maxHeight);
     };
 
-    Native["javax/microedition/lcdui/Graphics.isScreenGraphics.()Z"] = function() {
-        return isScreenGraphics(this);
-    };
-
     Native["javax/microedition/lcdui/Graphics.copyArea.(IIIIIII)V"] = function(x_src, y_src, width, height, x_dest, y_dest, anchor) {
         if (isScreenGraphics(this)) {
             throw $.newIllegalStateException();
@@ -597,11 +593,11 @@ var currentlyFocusedTextEditor;
         return this.transY;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getMaxWidth.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getMaxWidth.()S"] = function() {
         return this.maxWidth;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getMaxHeight.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getMaxHeight.()S"] = function() {
         return this.maxHeight;
     };
 
@@ -828,10 +824,6 @@ var currentlyFocusedTextEditor;
                           transform, x_dest, y_dest, anchor)) {
             throw $.newIllegalArgumentException();
         }
-    };
-
-    Native["javax/microedition/lcdui/Graphics.renderRegion.(Ljavax/microedition/lcdui/Image;IIIIIIII)Z"] = function(image, x_src, y_src, width, height, transform, x_dest, y_dest, anchor) {
-        return renderRegion(this, image, x_src, y_src, width, height, transform, x_dest, y_dest, anchor);
     };
 
     Native["javax/microedition/lcdui/Graphics.drawImage.(Ljavax/microedition/lcdui/Image;III)V"] = function(image, x, y, anchor) {

--- a/tests/javax/microedition/lcdui/TestGraphics.java
+++ b/tests/javax/microedition/lcdui/TestGraphics.java
@@ -1,0 +1,20 @@
+package javax.microedition.lcdui;
+
+import gnu.testlet.TestHarness;
+import gnu.testlet.Testlet;
+
+public class TestGraphics implements Testlet {
+    public int getExpectedPass() { return 2; }
+    public int getExpectedFail() { return 0; }
+    public int getExpectedKnownFail() { return 0; }
+
+    public void test(TestHarness th) {
+      Image image = Image.createImage(240, 320);
+      Graphics g = image.getGraphics();
+
+      short width = g.getMaxWidth();
+      th.check(width, 240);
+      short height = g.getMaxHeight();
+      th.check(height, 320);
+    }
+}


### PR DESCRIPTION
Remove more `Graphics` methods that can't be called.

Make the native implementations of `Graphics.getMaxWidth` and
`Graphics.getMaxHeight` actually match the signature of those methods.