### PR TITLE
Don't show '0' before '10' when there are n minutes and 10 seconds left

### DIFF
--- a/midp/sms.js
+++ b/midp/sms.js
@@ -79,7 +79,7 @@ function promptForMessageText() {
 
       var text = minutes + ":";
 
-      if (seconds > 10) {
+      if (seconds >= 10) {
         text += seconds;
       } else {
         text += "0" + seconds;


### PR DESCRIPTION
We're currently showing "4:010" when we should show "4:10".