### PR TITLE
remove localBase

### DIFF
--- a/interpreter.ts
+++ b/interpreter.ts
@@ -350,52 +350,52 @@ module J2ME {
             stack.push2(constant);
             break;
           case Bytecodes.ILOAD:
-            stack.push(frame.getLocal(frame.read8()));
+            stack.push(frame.local[frame.read8()]);
             break;
           case Bytecodes.FLOAD:
-            stack.push(frame.getLocal(frame.read8()));
+            stack.push(frame.local[frame.read8()]);
             break;
           case Bytecodes.ALOAD:
-            stack.push(frame.getLocal(frame.read8()));
+            stack.push(frame.local[frame.read8()]);
             break;
           case Bytecodes.ALOAD_ILOAD:
-            stack.push(frame.getLocal(frame.read8()));
+            stack.push(frame.local[frame.read8()]);
             frame.pc ++;
-            stack.push(frame.getLocal(frame.read8()));
+            stack.push(frame.local[frame.read8()]);
             break;
           case Bytecodes.LLOAD:
           case Bytecodes.DLOAD:
-            stack.push2(frame.getLocal(frame.read8()));
+            stack.push2(frame.local[frame.read8()]);
             break;
           case Bytecodes.ILOAD_0:
           case Bytecodes.ILOAD_1:
           case Bytecodes.ILOAD_2:
           case Bytecodes.ILOAD_3:
-            stack.push(frame.getLocal(op - Bytecodes.ILOAD_0));
+            stack.push(frame.local[op - Bytecodes.ILOAD_0]);
             break;
           case Bytecodes.FLOAD_0:
           case Bytecodes.FLOAD_1:
           case Bytecodes.FLOAD_2:
           case Bytecodes.FLOAD_3:
-            stack.push(frame.getLocal(op - Bytecodes.FLOAD_0));
+            stack.push(frame.local[op - Bytecodes.FLOAD_0]);
             break;
           case Bytecodes.ALOAD_0:
           case Bytecodes.ALOAD_1:
           case Bytecodes.ALOAD_2:
           case Bytecodes.ALOAD_3:
-            stack.push(frame.getLocal(op - Bytecodes.ALOAD_0));
+            stack.push(frame.local[op - Bytecodes.ALOAD_0]);
             break;
           case Bytecodes.LLOAD_0:
           case Bytecodes.LLOAD_1:
           case Bytecodes.LLOAD_2:
           case Bytecodes.LLOAD_3:
-            stack.push2(frame.getLocal(op - Bytecodes.LLOAD_0));
+            stack.push2(frame.local[op - Bytecodes.LLOAD_0]);
             break;
           case Bytecodes.DLOAD_0:
           case Bytecodes.DLOAD_1:
           case Bytecodes.DLOAD_2:
           case Bytecodes.DLOAD_3:
-            stack.push2(frame.getLocal(op - Bytecodes.DLOAD_0));
+            stack.push2(frame.local[op - Bytecodes.DLOAD_0]);
             break;
           case Bytecodes.IALOAD:
           case Bytecodes.FALOAD:
@@ -556,7 +556,7 @@ module J2ME {
           case Bytecodes.IINC_GOTO:
             index = frame.read8();
             value = frame.read8Signed();
-            frame.setLocal(index, frame.getLocal(index) + value);
+            frame.setLocal(index, frame.local[index] + value);
             frame.pc ++;
             frame.pc = frame.readTargetPC();
             break;
@@ -876,7 +876,7 @@ module J2ME {
             frame.pc = pc;
             break;
           case Bytecodes.RET:
-            frame.pc = frame.getLocal(frame.read8());
+            frame.pc = frame.local[frame.read8()];
             break;
           case Bytecodes.I2L:
             stack.push2(Long.fromInt(stack.pop()));
@@ -1188,7 +1188,7 @@ module J2ME {
                 if (!calleeFrame.lockObject) {
                   frame.lockObject = calleeTargetMethodInfo.isStatic
                     ? calleeTargetMethodInfo.classInfo.getClassObject()
-                    : frame.getLocal(0);
+                    : frame.local[0];
                 }
                 ctx.monitorEnter(calleeFrame.lockObject);
                 if (U === VMState.Pausing || U === VMState.Stopping) {

--- a/interpreter.ts
+++ b/interpreter.ts
@@ -1066,7 +1066,7 @@ module J2ME {
                 !calleeTargetMethodInfo.isSynchronized &&
                 !calleeTargetMethodInfo.isNative &&
                 calleeTargetMethodInfo.state !== MethodState.Compiled) {
-              var calleeFrame = Frame.create(calleeTargetMethodInfo, [], 0);
+              var calleeFrame = Frame.create(calleeTargetMethodInfo, []);
               ArrayUtilities.popManyInto(stack, calleeTargetMethodInfo.consumeArgumentSlots, calleeFrame.local);
               frames.push(calleeFrame);
               frame = calleeFrame;
@@ -1174,7 +1174,7 @@ module J2ME {
             }
             // Call method directly in the interpreter if we can.
             if (calleeTargetMethodInfo && !calleeTargetMethodInfo.isNative && calleeTargetMethodInfo.state !== MethodState.Compiled) {
-              var calleeFrame = Frame.create(calleeTargetMethodInfo, [], 0);
+              var calleeFrame = Frame.create(calleeTargetMethodInfo, []);
               ArrayUtilities.popManyInto(stack, calleeTargetMethodInfo.consumeArgumentSlots, calleeFrame.local);
               frames.push(calleeFrame);
               frame = calleeFrame;

--- a/interpreter.ts
+++ b/interpreter.ts
@@ -418,47 +418,47 @@ module J2ME {
           case Bytecodes.ISTORE:
           case Bytecodes.FSTORE:
           case Bytecodes.ASTORE:
-            frame.setLocal(frame.read8(), stack.pop());
+            frame.local[frame.read8()] = stack.pop();
             break;
           case Bytecodes.LSTORE:
           case Bytecodes.DSTORE:
-            frame.setLocal(frame.read8(), stack.pop2());
+            frame.local[frame.read8()] = stack.pop2();
             break;
           case Bytecodes.ISTORE_0:
           case Bytecodes.FSTORE_0:
           case Bytecodes.ASTORE_0:
-            frame.setLocal(0, stack.pop());
+            frame.local[0] = stack.pop();
             break;
           case Bytecodes.ISTORE_1:
           case Bytecodes.FSTORE_1:
           case Bytecodes.ASTORE_1:
-            frame.setLocal(1, stack.pop());
+            frame.local[1] = stack.pop();
             break;
           case Bytecodes.ISTORE_2:
           case Bytecodes.FSTORE_2:
           case Bytecodes.ASTORE_2:
-            frame.setLocal(2, stack.pop());
+            frame.local[2] = stack.pop();
             break;
           case Bytecodes.ISTORE_3:
           case Bytecodes.FSTORE_3:
           case Bytecodes.ASTORE_3:
-            frame.setLocal(3, stack.pop());
+            frame.local[3] = stack.pop();
             break;
           case Bytecodes.LSTORE_0:
           case Bytecodes.DSTORE_0:
-            frame.setLocal(0, stack.pop2());
+            frame.local[0] = stack.pop2();
             break;
           case Bytecodes.LSTORE_1:
           case Bytecodes.DSTORE_1:
-            frame.setLocal(1, stack.pop2());
+            frame.local[1] = stack.pop2();
             break;
           case Bytecodes.LSTORE_2:
           case Bytecodes.DSTORE_2:
-            frame.setLocal(2, stack.pop2());
+            frame.local[2] = stack.pop2();
             break;
           case Bytecodes.LSTORE_3:
           case Bytecodes.DSTORE_3:
-            frame.setLocal(3, stack.pop2());
+            frame.local[3] = stack.pop2();
             break;
           case Bytecodes.IASTORE:
           case Bytecodes.FASTORE:
@@ -551,12 +551,12 @@ module J2ME {
           case Bytecodes.IINC:
             index = frame.read8();
             value = frame.read8Signed();
-            frame.incLocal(index, value);
+            frame.local[index] += value | 0;
             break;
           case Bytecodes.IINC_GOTO:
             index = frame.read8();
             value = frame.read8Signed();
-            frame.setLocal(index, frame.local[index] + value);
+            frame.local[index] += frame.local[index];
             frame.pc ++;
             frame.pc = frame.readTargetPC();
             break;

--- a/native.js
+++ b/native.js
@@ -18,7 +18,7 @@ function asyncImpl(returnKind, promise) {
   }, function(exception) {
     var classInfo = CLASSES.getClass("org/mozilla/internal/Sys");
     var methodInfo = classInfo.getMethodByNameString("throwException", "(Ljava/lang/Exception;)V", true);
-    ctx.frames.push(Frame.create(methodInfo, [exception], 0));
+    ctx.frames.push(Frame.create(methodInfo, [exception]));
     ctx.execute();
   });
   $.pause("Async");
@@ -309,7 +309,7 @@ Native["java/lang/Class.invoke_clinit.()V"] = function() {
     var className = classInfo.getClassNameSlow();
     var clinit = classInfo.staticInitializer;
     if (clinit && clinit.classInfo.getClassNameSlow() === className) {
-        $.ctx.executeFrame(Frame.create(clinit, [], 0));
+        $.ctx.executeFrame(Frame.create(clinit, []));
     }
 };
 
@@ -538,7 +538,7 @@ Native["java/lang/Thread.start0.()V"] = function() {
 
     var classInfo = CLASSES.getClass("org/mozilla/internal/Sys");
     var run = classInfo.getMethodByNameString("runThread", "(Ljava/lang/Thread;)V", true);
-    newCtx.start([new Frame(run, [ this ], 0)]);
+    newCtx.start([Frame.create(run, [ this ])]);
 }
 
 Native["java/lang/Thread.isAlive.()Z"] = function() {

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -130,10 +130,6 @@ module J2ME {
       Frame.dirtyStack.push(this);
     }
 
-    setLocal(i: number, value: any) {
-      this.local[i] = value;
-    }
-
     incLocal(i: number, value: any) {
       this.local[i] += value | 0;
     }
@@ -240,16 +236,16 @@ module J2ME {
         case Bytecodes.ISTORE:
         case Bytecodes.FSTORE:
         case Bytecodes.ASTORE:
-          this.setLocal(this.read16(), stack.pop());
+          this.local[this.read16()] = stack.pop();
           break;
         case Bytecodes.LSTORE:
         case Bytecodes.DSTORE:
-          this.setLocal(this.read16(), stack.pop2());
+          this.local[this.read16()] = stack.pop2();
           break;
         case Bytecodes.IINC:
           var index = this.read16();
           var value = this.read16Signed();
-          this.setLocal(index, this.local[index] + value);
+          this.local[index] += value;
           break;
         case Bytecodes.RET:
           this.pc = this.local[this.read16()];

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -79,7 +79,6 @@ module J2ME {
     pc: number;
     opPC: number;
     cp: any;
-    localBase: number;
     lockObject: java.lang.Object;
 
     static dirtyStack: Frame [] = [];
@@ -87,24 +86,24 @@ module J2ME {
     /**
      * Denotes the start of the context frame stack.
      */
-    static Start: Frame = Frame.create(null, null, 0);
+    static Start: Frame = Frame.create(null, null);
 
     /**
      * Marks a frame set.
      */
-    static Marker: Frame = Frame.create(null, null, 0);
+    static Marker: Frame = Frame.create(null, null);
 
     static isMarker(frame: Frame) {
       return frame.methodInfo === null;
     }
 
-    constructor(methodInfo: MethodInfo, local: any [], localBase: number) {
+    constructor(methodInfo: MethodInfo, local: any []) {
       frameCount ++;
       this.stack = [];
-      this.reset(methodInfo, local, localBase);
+      this.reset(methodInfo, local);
     }
 
-    reset(methodInfo: MethodInfo, local: any [], localBase: number) {
+    reset(methodInfo: MethodInfo, local: any []) {
       this.methodInfo = methodInfo;
       this.cp = methodInfo ? methodInfo.classInfo.constantPool : null;
       this.code = methodInfo ? methodInfo.codeAttribute.code : null;
@@ -112,18 +111,17 @@ module J2ME {
       this.opPC = 0;
       this.stack.length = 0;
       this.local = local;
-      this.localBase = localBase;
       this.lockObject = null;
     }
 
-    static create(methodInfo: MethodInfo, local: any [], localBase: number): Frame {
+    static create(methodInfo: MethodInfo, local: any []): Frame {
       var dirtyStack = Frame.dirtyStack;
       if (dirtyStack.length) {
         var frame = dirtyStack.pop();
-        frame.reset(methodInfo, local, localBase);
+        frame.reset(methodInfo, local);
         return frame;
       } else {
-        return new Frame(methodInfo, local, localBase);
+        return new Frame(methodInfo, local);
       }
     }
 
@@ -133,16 +131,15 @@ module J2ME {
     }
 
     getLocal(i: number): any {
-      return this.local[this.localBase + i];
+      return this.local[i];
     }
 
     setLocal(i: number, value: any) {
-      this.local[this.localBase + i] = value;
+      this.local[i] = value;
     }
 
     incLocal(i: number, value: any) {
-      var j = this.localBase + i;
-      this.local[j] = this.local[j] + value | 0;
+      this.local[i] += value | 0;
     }
 
     read8(): number {
@@ -618,7 +615,7 @@ module J2ME {
 
     bailout(methodInfo: MethodInfo, pc: number, nextPC: number, local: any [], stack: any [], lockObject: java.lang.Object) {
       // perfWriter && perfWriter.writeLn("C Unwind: " + methodInfo.implKey);
-      var frame = Frame.create(methodInfo, local, 0);
+      var frame = Frame.create(methodInfo, local);
       frame.stack = stack;
       frame.pc = nextPC;
       frame.opPC = pc;

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -130,10 +130,6 @@ module J2ME {
       Frame.dirtyStack.push(this);
     }
 
-    getLocal(i: number): any {
-      return this.local[i];
-    }
-
     setLocal(i: number, value: any) {
       this.local[i] = value;
     }
@@ -235,11 +231,11 @@ module J2ME {
         case Bytecodes.ILOAD:
         case Bytecodes.FLOAD:
         case Bytecodes.ALOAD:
-          stack.push(this.getLocal(this.read16()));
+          stack.push(this.local[this.read16()]);
           break;
         case Bytecodes.LLOAD:
         case Bytecodes.DLOAD:
-          stack.push2(this.getLocal(this.read16()));
+          stack.push2(this.local[this.read16()]);
           break;
         case Bytecodes.ISTORE:
         case Bytecodes.FSTORE:
@@ -253,10 +249,10 @@ module J2ME {
         case Bytecodes.IINC:
           var index = this.read16();
           var value = this.read16Signed();
-          this.setLocal(index, this.getLocal(index) + value);
+          this.setLocal(index, this.local[index] + value);
           break;
         case Bytecodes.RET:
-          this.pc = this.getLocal(this.read16());
+          this.pc = this.local[this.read16()];
           break;
         default:
           var opName = Bytecodes[op];

--- a/vm/jvm.ts
+++ b/vm/jvm.ts
@@ -38,9 +38,9 @@ module J2ME {
 
       // The <init> frames go at the end of the array so they are executed first to initialize the thread and isolate.
       ctx.start([
-        Frame.create(isolateClassInfo.getMethodByNameString("start", "()V"), [ isolate ], 0),
+        Frame.create(isolateClassInfo.getMethodByNameString("start", "()V"), [ isolate ]),
         Frame.create(isolateClassInfo.getMethodByNameString("<init>", "(Ljava/lang/String;[Ljava/lang/String;)V"),
-                                       [ isolate, J2ME.newString(className.replace(/\./g, "/")), array ], 0)
+                                       [ isolate, J2ME.newString(className.replace(/\./g, "/")), array ])
       ]);
       release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
     }
@@ -70,9 +70,9 @@ module J2ME {
       }
 
       ctx.start([
-        Frame.create(entryPoint, [ args ], 0),
+        Frame.create(entryPoint, [ args ]),
         Frame.create(CLASSES.java_lang_Thread.getMethodByNameString("<init>", "(Ljava/lang/String;)V"),
-                     [ runtime.mainThread, J2ME.newString("main") ], 0)
+                     [ runtime.mainThread, J2ME.newString("main") ])
       ]);
       release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
     }

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1273,7 +1273,7 @@ module J2ME {
     // Adapter for the most common case.
     if (!methodInfo.isSynchronized && !methodInfo.hasTwoSlotArguments) {
       var method = function fastInterpreterFrameAdapter() {
-        var frame = Frame.create(methodInfo, [], 0);
+        var frame = Frame.create(methodInfo, []);
         var j = 0;
         if (!methodInfo.isStatic) {
           frame.setLocal(j++, this);
@@ -1289,7 +1289,7 @@ module J2ME {
     }
 
     var method = function interpreterFrameAdapter() {
-      var frame = Frame.create(methodInfo, [], 0);
+      var frame = Frame.create(methodInfo, []);
       var j = 0;
       if (!methodInfo.isStatic) {
         frame.setLocal(j++, this);

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1276,11 +1276,11 @@ module J2ME {
         var frame = Frame.create(methodInfo, []);
         var j = 0;
         if (!methodInfo.isStatic) {
-          frame.setLocal(j++, this);
+          frame.local[j++] = this;
         }
         var slots = methodInfo.argumentSlots;
         for (var i = 0; i < slots; i++) {
-          frame.setLocal(j++, arguments[i]);
+          frame.local[j++] = arguments[i];
         }
         return $.ctx.executeFrame(frame);
       };
@@ -1292,15 +1292,15 @@ module J2ME {
       var frame = Frame.create(methodInfo, []);
       var j = 0;
       if (!methodInfo.isStatic) {
-        frame.setLocal(j++, this);
+        frame.local[j++] = this;
       }
       var signatureKinds = methodInfo.signatureKinds;
       release || assert (arguments.length === signatureKinds.length - 1,
         "Number of adapter frame arguments (" + arguments.length + ") does not match signature descriptor.");
       for (var i = 1; i < signatureKinds.length; i++) {
-        frame.setLocal(j++, arguments[i - 1]);
+        frame.local[j++] = arguments[i - 1];
         if (isTwoSlot(signatureKinds[i])) {
-          frame.setLocal(j++, null);
+          frame.local[j++] = null;
         }
       }
       if (methodInfo.isSynchronized) {

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1307,7 +1307,7 @@ module J2ME {
         if (!frame.lockObject) {
           frame.lockObject = methodInfo.isStatic
             ? methodInfo.classInfo.getClassObject()
-            : frame.getLocal(0);
+            : frame.local[0];
         }
         $.ctx.monitorEnter(frame.lockObject);
         if (U === VMState.Pausing) {


### PR DESCRIPTION
Since `Frame.localBase` is always 0, there is no need to be an attribute of Frame object. Also we don't need the wrapper functions which depends on the `localBase` attribute as well.
