### PR TITLE
Don't create unneeded HTMLAudioElement

### DIFF
--- a/midp/media.js
+++ b/midp/media.js
@@ -227,8 +227,6 @@ function AudioPlayer(playerContainer) {
         }
     }.bind(this));
 
-    /* @type HTMLAudioElement */
-    this.audio = new Audio();
     this.paused = true;
     this.loaded = false;
     this.volume = 100;


### PR DESCRIPTION
Noticed this is unused while looking into https://github.com/mozilla/j2me.js/issues/1000