### PR TITLE
add make target to package app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.jar
 *.jad
 *.class
-*.zip
 .DS_Store
 certs/j2se_main.ks
 certs/j2se_test.ks

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jar
 *.jad
 *.class
+*.zip
 .DS_Store
 certs/j2se_main.ks
 certs/j2se_test.ks

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,10 @@ certs:
 app: config-build java certs j2me aot bld/main-all.js
 	tools/package.sh
 
+package: app
+	rm -f package.zip
+	cd output && zip -r ../package.zip *
+
 benchmarks: java tests
 	make -C bench
 
@@ -280,3 +284,4 @@ clean:
 	rm -rf java/l10n/
 	rm -f java/custom/com/sun/midp/i18n/ResourceConstants.java java/custom/com/sun/midp/l10n/LocalizedStringsBase.java
 	make -C bench clean
+	rm -f package.zip


### PR DESCRIPTION
This adds a Make target, *package*, that creates a ZIP package for distribution as a packaged app. Once #1393 lands, we might consider naming the package after the name and version of the app being packaged.
