### PR TITLE
increase default CasperJS log level to reduce logging for Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,11 @@ VERSION ?=$(shell date +%s)
 PROFILE ?= 0
 BENCHMARK ?= 0
 CONSOLE ?= 1
+
+# Whether or not to print certain verbose messages during the build process.
+# We use this to keep the build log on Travis below its 10K line display limit.
 VERBOSE ?= 0
+export VERBOSE
 
 # Sensor support
 JSR_256 ?= 1

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -18,7 +18,6 @@ casper.on('remote.message', function(message) {
 
 casper.options.waitTimeout = 80000;
 casper.options.verbose = true;
-casper.options.logLevel = "debug";
 casper.options.viewportSize = { width: 240, height: 320 };
 casper.options.clientScripts = [
   "tests/mocks/getUserMedia.js",

--- a/tests/fs/automation.js
+++ b/tests/fs/automation.js
@@ -9,7 +9,6 @@ casper.on('remote.message', function(message) {
 
 casper.options.waitTimeout = 60000;
 casper.options.verbose = true;
-casper.options.logLevel = "debug";
 
 casper.options.onWaitTimeout = function() {
     this.echo("data:image/png;base64," + this.captureBase64('png'));

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -69,8 +69,13 @@ def wait_server(port):
 def run_test(script_path):
   global exit_code
 
-  script_process = subprocess.Popen(['casperjs', '--engine=slimerjs', 'test', script_path],
-                                    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
+  args = ['casperjs', '--engine=slimerjs']
+  if os.environ['VERBOSE'] != '0':
+    args.append('--log-level=debug')
+  args.extend(['test', script_path])
+
+  script_process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,  stderr=subprocess.STDOUT,
+                                    bufsize=1)
   output_streams = list(server_output_streams)
   output_streams.append(script_process.stdout)
 


### PR DESCRIPTION
We've exceeded the 10K log line display limit on Travis again. This should cut out ~4K lines of CasperJS logging.