### PR TITLE
free frames as much as possible

### DIFF
--- a/interpreter.ts
+++ b/interpreter.ts
@@ -166,6 +166,7 @@ module J2ME {
 
         return;
       }
+      frame.free();
       ctx.popFrame();
       frame = ctx.current();
       if (Frame.isMarker(frame)) {

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -620,7 +620,7 @@ module J2ME {
           this.bodyEmitter.writeLn("ins=O.lockObject;");
         }
         this.bodyEmitter.writeLn("pc=O.pc;");
-        this.bodyEmitter.writeLn("O=null;");
+        this.bodyEmitter.writeLn("O.free();O=null;");
         if (this.methodInfo.isSynchronized) {
           this.bodyEmitter.leaveAndEnter("}else{");
           this.emitMonitorEnter(this.bodyEmitter, 0, this.lockObject);


### PR DESCRIPTION
This pull request makes sure that all the frames are freed after using and I don't see significant performance regression.

|     Test    | Baseline Mean |  Mean | +/- |   %  |       P       |  Min  |  Max  | 
|:------------|--------------:|------:|----:|-----:|--------------:|------:|------:|
| startupTime |         683ms | 691ms | 7ms | 1.06 | INSIGNIFICANT | 608ms | 984ms | 
| startupTime |         683ms | 690ms | 6ms | 0.95 | INSIGNIFICANT | 610ms | 949ms | 
| startupTime |         683ms | 677ms | -7ms| -0.96| INSIGNIFICANT | 607ms | 862ms |