### PR TITLE
Name package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test tests j2me java certs app clean jasmin aot shumway config-build benchmarks
+.PHONY: all test tests j2me java certs app clean jasmin aot shumway config-build benchmarks package
 BASIC_SRCS=$(shell find . -maxdepth 2 -name "*.ts" -not -path "./bld/*") config.ts
 JIT_SRCS=$(shell find jit -name "*.ts" -not -path "./bld/*")
 SHUMWAY_SRCS=$(shell find shumway -name "*.ts")
@@ -308,8 +308,8 @@ app: config-build java certs j2me aot bld/main-all.js icon $(TESTS_JAR)
 	tools/package.sh
 
 package: app
-	rm -f package.zip
-	cd output && zip -r $(NAME)-$(VERSION).zip *
+	rm -f $(NAME)-$(VERSION).zip
+	cd output && zip -r '../$(NAME)-$(VERSION).zip' *
 
 benchmarks: java tests
 	make -C bench

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ app: config-build java certs j2me aot bld/main-all.js icon $(TESTS_JAR)
 
 package: app
 	rm -f package.zip
-	cd output && zip -r ../package.zip *
+	cd output && zip -r $(NAME)-$(VERSION).zip *
 
 benchmarks: java tests
 	make -C bench

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ app: config-build java certs j2me aot bld/main-all.js icon $(TESTS_JAR)
 	tools/package.sh
 
 package: app
-	rm -f $(NAME)-$(VERSION).zip
+	rm -f '$(NAME)-$(VERSION).zip'
 	cd output && zip -r '../$(NAME)-$(VERSION).zip' *
 
 benchmarks: java tests


### PR DESCRIPTION
This makes `make package` name the ZIP after the name and version of the app being packaged.

It accommodates app names with spaces and other punctuation. I considered removing those characters, but I'm not sure it's necessary, given modern filesystems.

It also makes *package* a phony target, which it should have been in the first place.

And I experimented with putting the package into the output/ subdirectory, but then I realized a reason to keep it in the top-level directory: WebIDE itself packages the entire contents of output/ when you use it to push a packaged app to a device, so putting the package generated by `make package` into output/ would mean that it would get included in the package that WebIDE creates, effectively doubling the size of that package.
