### PR TITLE
Don't *flushAll* during startup

### DIFF
--- a/libs/fs.js
+++ b/libs/fs.js
@@ -598,7 +598,11 @@ var fs = (function() {
   // filesystem implementation requires the `finalize` method to save cached
   // file data if user doesn't flush or close the file explicitly. To avoid
   // losing data, we flush files periodically.
-  setInterval(flushAll, 5000);
+  // We start to flush periodically after startup has been completed (25 seconds
+  // is a good estimate).
+  setTimeout(function() {
+    setInterval(flushAll, 5000);
+  }, 20000);
 
   // Flush files when app goes into background.
   window.addEventListener("pagehide", flushAll);


### PR DESCRIPTION
Unfortunately I forgot to copy the benchmark results before closing the app... With 30 rounds, startup time was 1 second better (a few ms over 1 s).