### PR TITLE
Directly use AmsUtil instead of going through MIDletSuiteUtils

### DIFF
--- a/java/custom/com/nokia/mid/s40/bg/BGUtils.java
+++ b/java/custom/com/nokia/mid/s40/bg/BGUtils.java
@@ -1,6 +1,7 @@
 package com.nokia.mid.s40.bg;
 
-import com.sun.midp.main.MIDletSuiteUtils;
+import com.sun.midp.main.AmsUtil;
+import com.sun.midp.midletsuite.MIDletSuiteStorage;
 
 class WaitUserInteractionThread extends Thread {
     public WaitUserInteractionThread() {
@@ -31,10 +32,8 @@ public class BGUtils {
         return;
       }
 
-      int midletNumber = BGUtils.getFGMIDletNumber();
-      String midletClass = BGUtils.getFGMIDletClass();
-
-      MIDletSuiteUtils.execute(midletNumber, midletClass, null);
+      AmsUtil.executeWithArgs(MIDletSuiteStorage.getMIDletSuiteStorage(), 0, BGUtils.getFGMIDletNumber(),
+                              BGUtils.getFGMIDletClass(), null, null, null, null, -1, -1, -1, null, false);
     }
 
     private static native void addSystemProperties(String args);
@@ -47,7 +46,9 @@ public class BGUtils {
         try {
             BGUtils.addSystemProperties(args);
 
-            MIDletSuiteUtils.execute(midletNumber, BGUtils.getFGMIDletClass(), null);
+            AmsUtil.executeWithArgs(MIDletSuiteStorage.getMIDletSuiteStorage(), 0, midletNumber,
+                                    BGUtils.getFGMIDletClass(), null, null, null, null, -1, -1,
+                                    -1, null, false);
         } catch (Exception e) {
             System.out.println("Unexpected exception: " + e);
             e.printStackTrace();

--- a/java/custom/com/nokia/mid/s40/bg/BGUtils.java
+++ b/java/custom/com/nokia/mid/s40/bg/BGUtils.java
@@ -27,7 +27,7 @@ public class BGUtils {
       new WaitUserInteractionThread().start();
     }
 
-    public static void startMIDlet() {
+    static void startMIDlet() {
       if (BGUtils.launchMIDletCalled) {
         return;
       }

--- a/java/custom/com/sun/midp/main/AmsUtil.java
+++ b/java/custom/com/sun/midp/main/AmsUtil.java
@@ -132,7 +132,7 @@ public class AmsUtil {
      * @return false to signal that the MIDlet suite does not have to exit
      * before the MIDlet is run
      */
-    static boolean executeWithArgs(MIDletSuiteStorage midletSuiteStorage,
+    public static boolean executeWithArgs(MIDletSuiteStorage midletSuiteStorage,
             int externalAppId, int id, String midlet,
             String displayName, String arg0, String arg1, String arg2,
             int memoryReserved, int memoryTotal, int priority,


### PR DESCRIPTION
These commits were part of #1030, but #1030 has been backed out.