### PR TITLE
Don't create temporary strings in bin2String

### DIFF
--- a/midp/crypto.js
+++ b/midp/crypto.js
@@ -29,12 +29,13 @@ MIDP.getMD5Hasher = function(data) {
     return hasher;
 };
 
+var bin2StringResult = new Array();
 MIDP.bin2String = function(array) {
-  var result = new Array(array.length);
+  bin2StringResult.length = array.length;
   for (var i = 0; i < array.length; i++) {
-    result[i] = String.fromCharCode(array[i] & 0xff);
+    bin2StringResult[i] = String.fromCharCode(array[i] & 0xff);
   }
-  return result.join("");
+  return bin2StringResult.join("");
 };
 
 Native["com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V"] = function(inBuf, inOff, inLen, state, num, count, data) {

--- a/midp/crypto.js
+++ b/midp/crypto.js
@@ -30,11 +30,11 @@ MIDP.getMD5Hasher = function(data) {
 };
 
 MIDP.bin2String = function(array) {
-  var result = "";
+  var result = new Array(array.length);
   for (var i = 0; i < array.length; i++) {
-    result += String.fromCharCode(array[i] & 0xff);
+    result[i] = String.fromCharCode(array[i] & 0xff);
   }
-  return result;
+  return result.join("");
 };
 
 Native["com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V"] = function(inBuf, inOff, inLen, state, num, count, data) {


### PR DESCRIPTION
This makes the MD5 benchmark ~2x faster (~280 ms -> ~120 ms).