### PR TITLE
update closure compiler version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ build_tools/soot-trunk.jar: build_tools/.soot_version
 	touch build_tools/soot-trunk.jar
 
 build_tools/closure.jar: build_tools/.closure_compiler_version
-	wget -P build_tools -N https://github.com/mykmelez/closure-compiler/releases/download/$(CLOSURE_COMPILER_VERSION)/closure.jar
+	wget -P build_tools https://github.com/mykmelez/closure-compiler/releases/download/$(CLOSURE_COMPILER_VERSION)/closure.jar
 	touch build_tools/closure.jar
 
 $(PREPROCESS_DESTS): $(PREPROCESS_SRCS) .checksum

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ SOOT_VERSION=25Mar2015
 OLD_SOOT_VERSION := $(shell [ -f build_tools/.soot_version ] && cat build_tools/.soot_version)
 $(shell [ "$(SOOT_VERSION)" != "$(OLD_SOOT_VERSION)" ] && echo $(SOOT_VERSION) > build_tools/.soot_version)
 
-CLOSURE_COMPILER_VERSION=j2me.js-v20150327
+CLOSURE_COMPILER_VERSION=j2me.js-v20150428
 OLD_CLOSURE_COMPILER_VERSION := $(shell [ -f build_tools/.closure_compiler_version ] && cat build_tools/.closure_compiler_version)
 $(shell [ "$(CLOSURE_COMPILER_VERSION)" != "$(OLD_CLOSURE_COMPILER_VERSION)" ] && echo $(CLOSURE_COMPILER_VERSION) > build_tools/.closure_compiler_version)
 

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ build_tools/$(XULRUNNER_PATH): build_tools/.xulrunner_version
 
 build_tools/soot-trunk.jar: build_tools/.soot_version
 	rm -f build_tools/soot-trunk.jar
-	wget -P build_tools -N https://github.com/marco-c/soot/releases/download/soot-25Mar2015/soot-trunk.jar
+	wget -P build_tools https://github.com/marco-c/soot/releases/download/soot-25Mar2015/soot-trunk.jar
 	touch build_tools/soot-trunk.jar
 
 build_tools/closure.jar: build_tools/.closure_compiler_version


### PR DESCRIPTION
Per @mbebenita in https://github.com/mozilla/j2me.js/issues/1479#issuecomment-96946383, this updates the Closure compiler. But GitHub's CDN doesn't appear to be able to handle wget's `-N` option, so downloading the new version fails if you have an existing version:

```
04-28 00:57 > make
…
wget -P build_tools -N https://github.com/mykmelez/closure-compiler/releases/download/j2me.js-v20150428/closure.jar
--2015-04-28 00:57:22--  https://github.com/mykmelez/closure-compiler/releases/download/j2me.js-v20150428/closure.jar
Resolving github.com... 192.30.252.131
Connecting to github.com|192.30.252.131|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://s3.amazonaws.com/github-cloud/releases/30269370/491a21ae-ed3f-11e4-9b4f-f420af70d4b5.jar?response-content-disposition=attachment%3B%20filename%3Dclosure.jar&response-content-type=application/octet-stream&AWSAccessKeyId=AKIAISTNZFOVBIJMK3TQ&Expires=1430207903&Signature=Y3ggJip37d8pcKZg8E%2BZypYWtks%3D [following]
--2015-04-28 00:57:23--  https://s3.amazonaws.com/github-cloud/releases/30269370/491a21ae-ed3f-11e4-9b4f-f420af70d4b5.jar?response-content-disposition=attachment%3B%20filename%3Dclosure.jar&response-content-type=application/octet-stream&AWSAccessKeyId=AKIAISTNZFOVBIJMK3TQ&Expires=1430207903&Signature=Y3ggJip37d8pcKZg8E%2BZypYWtks%3D
Resolving s3.amazonaws.com... 54.231.244.0
Connecting to s3.amazonaws.com|54.231.244.0|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2015-04-28 00:57:23 ERROR 403: Forbidden.

make: *** [build_tools/closure.jar] Error 8
```

The same is true for the old version, so it doesn't appear specific to the new one. I'm not sure what's going on nor how to work around it. @marco-c any ideas?
