### PR TITLE
install a specific, known-good version of typescript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 before_script:
   - "sh -e /etc/init.d/xvfb start"
   - npm install casperjs
-  - npm install typescript
+  - npm install typescript@1.4.1
   - wget -P /tmp/j2me.js -N https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/37.0b7-candidates/build1/jsshell-linux-x86_64.zip
   - unzip -d /tmp/js /tmp/j2me.js/jsshell-linux-x86_64.zip
   - export PATH=$PATH:/tmp/js


### PR DESCRIPTION
Specifically, 1.4.1. Since 1.5.0-beta was released today, and it's causing build failures, like https://travis-ci.org/mozilla/j2me.js/builds/60758357:

```
Building J2ME
tsc --sourcemap --target ES5 references.ts -d --out bld/j2me.js
jit/blockMap.ts(350,32): error TS2304: Cannot find name 'Map'.
jit/blockMap.ts(350,78): error TS2304: Cannot find name 'Map'.
jit/compiler.ts(206,37): error TS2304: Cannot find name 'Map'.
metrics.ts(29,22): error TS2304: Cannot find name 'Map'.
metrics.ts(95,22): error TS2304: Cannot find name 'Map'.
metrics.ts(96,21): error TS2304: Cannot find name 'Map'.
metrics.ts(97,19): error TS2304: Cannot find name 'Map'.
utilities.ts(181,40): error TS2304: Cannot find name 'Map'.
vm/classRegistry.ts(21,18): error TS2304: Cannot find name 'Map'.
vm/classRegistry.ts(27,25): error TS2304: Cannot find name 'Map'.
vm/classRegistry.ts(29,14): error TS2304: Cannot find name 'Map'.
vm/runtime.ts(271,31): error TS2304: Cannot find name 'Map'.
vm/runtime.ts(271,67): error TS2304: Cannot find name 'Map'.
vm/runtime.ts(412,22): error TS2304: Cannot find name 'Set'.
vm/runtime.ts(422,14): error TS2304: Cannot find name 'Set'.
vm/runtime.ts(442,26): error TS2304: Cannot find name 'Set'.
jit/compiler.ts(206,37): error TS4078: Parameter 'jarFiles' of exported function has or is using private name 'Map'.
metrics.ts(97,19): error TS4043: Return type of public property getter from exported class has or is using private name 'Map'.
utilities.ts(181,40): error TS4060: Return type of exported function has or is using private name 'Map'.
vm/classRegistry.ts(21,18): error TS4031: Public property 'sourceFiles' of exported class has or is using private name 'Map'.
vm/classRegistry.ts(27,25): error TS4031: Public property 'missingSourceFiles' of exported class has or is using private name 'Map'.
vm/classRegistry.ts(29,14): error TS4031: Public property 'classes' of exported class has or is using private name 'Map'.
vm/runtime.ts(271,31): error TS4025: Exported variable 'internedStrings' has or is using private name 'Map'.
vm/runtime.ts(422,14): error TS4031: Public property 'allCtxs' of exported class has or is using private name 'Set'.
make: *** [bld/j2me.js] Error 2
The command "make test" exited with 2.
```