### PR TITLE
call location.replace to avoid creating history entry while collecting memory

### DIFF
--- a/gc.js
+++ b/gc.js
@@ -1,3 +1,3 @@
 Benchmark.forceCollectors().then(function() {
-  window.location = window.location.href.replace("gc.html", "index.html");
+  window.location.replace(window.location.href.replace("gc.html", "index.html"));
 });

--- a/index.js.in
+++ b/index.js.in
@@ -724,7 +724,7 @@ DumbPipe.registerOpener("windowOpen", function(message, sender) {
 
 // #if BENCHMARK == "true"
 DumbPipe.registerOpener("gcReload", function(message, sender) {
-  window.location = window.location.href.replace("index.html", "gc.html");
+  window.location.replace(window.location.href.replace("index.html", "gc.html"));
 });
 // #endif
 


### PR DESCRIPTION
@marco-c @brendandahl I thought this might help address #1508, but it doesn't seem to make a difference. Nevertheless, we should probably do it anyway, to avoid creating history while running the startup benchmark.
