### PR TITLE
Bring back the gamepad

### DIFF
--- a/midp/midp.js
+++ b/midp/midp.js
@@ -203,10 +203,6 @@ var MIDP = (function() {
     return bytes;
   };
 
-  if (config.gamepad && !/no|0/.test(config.gamepad)) {
-    document.documentElement.classList.add('gamepad');
-  }
-
   var verticalChrome;
   var horizontalChrome;
   var physicalScreenWidth;

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -203,6 +203,10 @@ var MIDP = (function() {
     return bytes;
   };
 
+  if (config.gamepad && !/no|0/.test(config.gamepad)) {
+    document.documentElement.classList.add('gamepad');
+  }
+
   var verticalChrome;
   var horizontalChrome;
   var physicalScreenWidth;

--- a/style/main.css.in
+++ b/style/main.css.in
@@ -168,14 +168,14 @@ button {
 #gamepad #down { left: 75px; bottom: 0px; }
 #gamepad #left { left: 25px; bottom: 20px; }
 #gamepad #right { left: 125px; bottom: 20px; }
-#gamepad #fire { left: 250px; bottom: 20px; }
+#gamepad #fire { left: 175px; bottom: 20px; }
 
-.gamepad body > #gamepad {
+.gamepad #display > #gamepad {
   display: block;
   z-index: 102;
 }
 
-.gamepad body > #gamepad button {
+.gamepad #display > #gamepad button {
   display: block;
 }
 


### PR DESCRIPTION
Properly set the "gamepad" class on the document element when the
gamepad parameter is specified.

Fix broken CSS related to gamepad.