### PR TITLE
Clean up MIDP foreground info

### DIFF
--- a/game-ui.js
+++ b/game-ui.js
@@ -1,11 +1,39 @@
-function makeSendKey(keyCode) {
-  return function() {
-    MIDP.keyPress(keyCode);
-  }
+document.getElementById("up").onmousedown = function() {
+  MIDP.sendKeyPress(119);
 }
 
-document.getElementById("up").ontouchstart = makeSendKey(119);
-document.getElementById("down").ontouchstart = makeSendKey(115);
-document.getElementById("left").ontouchstart = makeSendKey(97);
-document.getElementById("right").ontouchstart = makeSendKey(100);
-document.getElementById("fire").ontouchstart = makeSendKey(32);
+document.getElementById("up").onmouseup = function() {
+  MIDP.sendKeyRelease(119);
+}
+
+document.getElementById("down").onmousedown = function() {
+  MIDP.sendKeyPress(115);
+}
+
+document.getElementById("down").onmouseup = function() {
+  MIDP.sendKeyRelease(115);
+}
+
+document.getElementById("left").onmousedown = function() {
+  MIDP.sendKeyPress(97);
+}
+
+document.getElementById("left").onmouseup = function() {
+  MIDP.sendKeyRelease(97);
+}
+
+document.getElementById("right").onmousedown = function() {
+  MIDP.sendKeyPress(100);
+}
+
+document.getElementById("right").onmouseup = function() {
+  MIDP.sendKeyRelease(100);
+}
+
+document.getElementById("fire").onmousedown = function() {
+  MIDP.sendKeyPress(32);
+}
+
+document.getElementById("fire").onmouseup = function() {
+  MIDP.sendKeyRelease(32);
+}


### PR DESCRIPTION
Create an `FG` module inside of `MIDP` that keeps track of the
foreground isolate ID and the foreground display ID. Send native events
through a `FG` function so that we always properly check that the
display ID and isolate ID are valid.

Make the gamepad buttons send both press and release events. Use
mousedown and mouseup events instead of touchstart events.

Remove the unused SCREEN_REPAINT_EVENT constant.

Rename `MIDP.keyPress` and `MIDP.keyRelease` to `MIDP.send*`. This is
more consistent with other similar functions.

Remove the `MIDP.displayId` property.