### PR TITLE
delete all three IDB databases

### DIFF
--- a/libs/compiled-method-cache.js
+++ b/libs/compiled-method-cache.js
@@ -157,10 +157,20 @@ var CompiledMethodCache = (function() {
     }
   }
 
+  function deleteDatabase() {
+    return new Promise(function(resolve, reject) {
+      database = null;
+      var request = indexedDB.deleteDatabase(DATABASE);
+      request.onsuccess = resolve;
+      request.onerror = function() { reject(request.error.name) };
+    });
+  }
+
   return {
     get: get,
     put: put,
     clear: clear,
+    deleteDatabase: deleteDatabase,
   };
 
 })();

--- a/libs/fs.js
+++ b/libs/fs.js
@@ -917,15 +917,6 @@ var fs = (function() {
     return store.import(blob, cb);
   }
 
-  function deleteStore() {
-    return new Promise(function(resolve, reject) {
-      store.db = null;
-      var request = indexedDB.deleteDatabase("asyncStorage");
-      request.onsuccess = resolve;
-      request.onerror = reject;
-    });
-  }
-
   return {
     normalize: normalizePath,
     dirname: dirname,
@@ -953,7 +944,6 @@ var fs = (function() {
     syncStore: syncStore,
     exportStore: exportStore,
     importStore: importStore,
-    deleteStore: deleteStore,
     createUniqueFile: createUniqueFile,
     getBlob: getBlob,
   };

--- a/libs/fs.js
+++ b/libs/fs.js
@@ -917,6 +917,15 @@ var fs = (function() {
     return store.import(blob, cb);
   }
 
+  function deleteDatabase() {
+    return new Promise(function(resolve, reject) {
+      store.db = null;
+      var request = indexedDB.deleteDatabase(Store.DBNAME);
+      request.onsuccess = resolve;
+      request.onerror = function() { reject(request.error.name) };
+    });
+  }
+
   return {
     normalize: normalizePath,
     dirname: dirname,
@@ -944,6 +953,7 @@ var fs = (function() {
     syncStore: syncStore,
     exportStore: exportStore,
     importStore: importStore,
+    deleteDatabase: deleteDatabase,
     createUniqueFile: createUniqueFile,
     getBlob: getBlob,
   };

--- a/libs/jarstore.js
+++ b/libs/jarstore.js
@@ -187,6 +187,15 @@ var JARStore = (function() {
     });
   }
 
+  function deleteDatabase() {
+    return new Promise(function(resolve, reject) {
+      database = null;
+      var request = indexedDB.deleteDatabase(DATABASE);
+      request.onsuccess = resolve;
+      request.onerror = function() { reject(request.error.name) };
+    });
+  }
+
   return {
     addBuiltIn: addBuiltIn,
     installJAR: installJAR,
@@ -195,6 +204,7 @@ var JARStore = (function() {
     loadFile: loadFile,
     getJAD: getJAD,
     clear: clear,
+    deleteDatabase: deleteDatabase,
   };
 })();
 

--- a/main.html.in
+++ b/main.html.in
@@ -225,13 +225,13 @@
         <label><input type="checkbox" id="perfWriter">Perf</label>
       </section>
       <section>
-        <button id="deleteDatabases">Delete Databases</button>
         <button id="exportstorage">Export File System</button>
-        <div>Import storage:</div>
+        <div>Import File System:</div>
         <input type="file" id="importstoragefile">
         <input type="text" id="importstorageurl" placeholder="URL to FS backup">
         <button id="importstorage">Import</button>
         <button id="clearCompiledMethodCache">Clear Compiled Method Cache</button>
+        <button id="deleteDatabases">Delete IDB Databases</button>
         <button id="printAllExceptions">Print all exceptions: OFF</button>
         <button id="clearCounters">Clear Counters</button>
         <button id="dumpCounters">Dump Counters</button>

--- a/main.html.in
+++ b/main.html.in
@@ -225,7 +225,7 @@
         <label><input type="checkbox" id="perfWriter">Perf</label>
       </section>
       <section>
-        <button id="deleteDatabase">Delete File System</button>
+        <button id="deleteDatabases">Delete Databases</button>
         <button id="exportstorage">Export File System</button>
         <div>Import storage:</div>
         <input type="file" id="importstoragefile">

--- a/main.js
+++ b/main.js
@@ -267,11 +267,16 @@ if (typeof Benchmark !== "undefined") {
 }
 
 window.onload = function() {
- document.getElementById("deleteDatabase").onclick = function() {
-   fs.deleteStore().then(function() {
-     console.log("Delete file system completed.");
-   }, function() {
-     console.log("Failed to delete file system.");
+ document.getElementById("deleteDatabases").onclick = function() {
+   ["asyncStorage", "CompiledMethodCache", "JARStore"].forEach(function(database) {
+     console.log("Deleting " + database + "…");
+     var req = indexedDB.deleteDatabase(database);
+     req.onsuccess = function() {
+       console.log("Deleted " + database + ".");
+     };
+     req.onerror = function() {
+       console.error("Error deleting " + database + ": " + req.error.name);
+     };
    });
  };
  document.getElementById("exportstorage").onclick = function() {

--- a/main.js
+++ b/main.js
@@ -268,15 +268,22 @@ if (typeof Benchmark !== "undefined") {
 
 window.onload = function() {
  document.getElementById("deleteDatabases").onclick = function() {
-   ["asyncStorage", "CompiledMethodCache", "JARStore"].forEach(function(database) {
-     console.log("Deleting " + database + "…");
-     var req = indexedDB.deleteDatabase(database);
-     req.onsuccess = function() {
-       console.log("Deleted " + database + ".");
-     };
-     req.onerror = function() {
-       console.error("Error deleting " + database + ": " + req.error.name);
-     };
+   fs.deleteDatabase().then(function() {
+     console.log("Deleted fs database.");
+   }).catch(function(error) {
+     console.log("Error deleting fs database: " + error);
+   });
+
+   CompiledMethodCache.deleteDatabase().then(function() {
+     console.log("Deleted CompiledMethodCache database.");
+   }).catch(function(error) {
+     console.log("Error deleting CompiledMethodCache database: " + error);
+   });
+
+   JARStore.deleteDatabase().then(function() {
+     console.log("Deleted JARStore database.");
+   }).catch(function(error) {
+     console.log("Error deleting JARStore database: " + error);
    });
  };
  document.getElementById("exportstorage").onclick = function() {


### PR DESCRIPTION
When you're trying to get back to the initial state of storage, it's useful to be able to blow away all three IDB databases. I think this is the most common need (and will satisfy others). You can always blow away an individual database via the console.
