### PR TITLE
Add a new customizable profiling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To use them, just add calls to `runtimeCounter.count(name, count = 1)`. To view 
   }
   ```
 
-The second, more heavy weight profiling tool is Shumway's timeline profiler. The profiler records `enter` / `leave` events in a large circular buffer that can be later displayed visually as a flame chart or saved in a text format. To use it, build j2me.js with `PROFILE=[1|2]`. Then wrap code regions that you're interested in measuring with calls to `timeline.enter` / `timeline.leave`.
+The second, more heavy weight profiling tool is Shumway's timeline profiler. The profiler records `enter` / `leave` events in a large circular buffer that can be later displayed visually as a flame chart or saved in a text format. To use it, build j2me.js with `PROFILE=[1|2|4]`. Then wrap code regions that you're interested in measuring with calls to `timeline.enter` / `timeline.leave`.
 
 Java methods are automatically wrapped with calls to `methodTimeline.enter` /  `methodTimeline.leave`. The resulting timeline is a very detailed trace of the application's execution. Note that this instrumentation has some overhead, and timing information of very short lived events may not be accurate and can lead to the entire application slowing down.
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ The tooltip displays:
 
 If you build with `PROFILE=2`, then the timeline will be saved to a text file instead of being shown in the flame chart. On desktop, you will be prompted to save the file. On the phone, the file will automatically be saved to `/sdcard/downloads/profile.txt`, which you can later pull with `adb pull`. Note that no timeline events under 0.1 ms are written to the file output. You can change this in `main.js` if you'd like.
 
+`PROFILE=4` works like `PROFILE=2`, but allows you to profile a custom "range" of the execution by adding calls to org.mozilla.internal.Sys::startProfile and org.mozilla.internal.Sys::stopProfile.
+
 `PROFILE=1` and `PROFILE=2` automatically profile (most of) cold startup, from *JVM.startIsolate0* to *DisplayDevice.gainedForeground0*.
 
 ## Benchmarks

--- a/java/custom/org/mozilla/internal/Sys.java
+++ b/java/custom/org/mozilla/internal/Sys.java
@@ -87,4 +87,7 @@ public final class Sys {
       t.notifyAll();
     }
   }
+
+  public native static void startProfile();
+  public native static void stopProfile();
 }

--- a/native.js
+++ b/native.js
@@ -946,6 +946,32 @@ Native["org/mozilla/internal/Sys.eval.(Ljava/lang/String;)V"] = function(src) {
     }
 };
 
+var profileStarted = false;
+Native["org/mozilla/internal/Sys.startProfile.()V"] = function() {
+    if (profile === 4) {
+        if (!profileStarted) {
+            profileStarted = true;
+
+            console.log("Start profile at: " + performance.now());
+            startTimeline();
+        }
+    }
+};
+
+var profileSaved = false;
+Native["org/mozilla/internal/Sys.stopProfile.()V"] = function() {
+    if (profile === 4) {
+        if (!profileSaved) {
+            profileSaved = true;
+
+            console.log("Stop profile at: " + performance.now());
+            setZeroTimeout(function() {
+                stopAndSaveTimeline();
+            });
+        }
+    }
+};
+
 Native["java/io/ByteArrayOutputStream.write.([BII)V"] = function(b, off, len) {
   if ((off < 0) || (off > b.length) || (len < 0) ||
       ((off + len) > b.length)) {


### PR DESCRIPTION
This can be used to select a profiling window by adding calls to Sys.startProfile and Sys.stopProfile.
For example I've used it to get a profile of the first call to Canvas::paint in CanvasLFImpl.