### PR TITLE
pause method timeline while awaiting async resolution

### DIFF
--- a/vm/context.ts
+++ b/vm/context.ts
@@ -317,6 +317,12 @@ module J2ME {
 
     id: number;
 
+    /**
+     * Whether or not the context is currently paused.  The profiler uses this
+     * to distinguish execution time from paused time in an async method.
+     */
+    paused: boolean = true;
+
     /*
      * Contains method frames separated by special frame instances called marker frames. These
      * mark the position in the frame stack where the interpreter starts execution.
@@ -502,6 +508,7 @@ module J2ME {
 
     execute() {
       this.setAsCurrentContext();
+      profile && this.resumeMethodTimeline();
       do {
         VM.execute();
         if (U) {
@@ -645,6 +652,26 @@ module J2ME {
       this.bailoutFrames.unshift(frame);
     }
 
+    pauseMethodTimeline() {
+      release || assert(!this.paused, "context is not paused");
+
+      if (profiling) {
+        this.methodTimeline.enter("<pause>", MethodType.Interpreted);
+      }
+
+      this.paused = true;
+    }
+
+    resumeMethodTimeline() {
+      release || assert(this.paused, "context is paused");
+
+      if (profiling) {
+        this.methodTimeline.leave("<pause>", MethodType.Interpreted);
+      }
+
+      this.paused = false;
+    }
+
     /**
      * Re-enters all the frames that are currently on the stack so the full stack
      * trace shows up in the profiler.
@@ -656,6 +683,10 @@ module J2ME {
           continue;
         }
         this.methodTimeline.enter(frame.methodInfo.implKey, MethodType.Interpreted);
+      }
+
+      if (this.paused) {
+        this.methodTimeline.enter("<pause>", MethodType.Interpreted);
       }
     }
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1337,7 +1337,7 @@ module J2ME {
             r = fn.apply(this, arguments);
         }
         if (U) {
-          assert(ctx.paused, "context is paused");
+          release || assert(ctx.paused, "context is paused");
 
           if (methodInfo.isNative) {
             // A fake frame that just returns is pushed so when the ctx resumes from the unwind

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -680,6 +680,7 @@ module J2ME {
       threadWriter && threadWriter.writeLn("yielding " + reason);
       runtimeCounter && runtimeCounter.count("yielding " + reason);
       U = VMState.Yielding;
+      profile && $.ctx.pauseMethodTimeline();
     }
 
     pause(reason: string) {
@@ -687,6 +688,7 @@ module J2ME {
       threadWriter && threadWriter.writeLn("pausing " + reason);
       runtimeCounter && runtimeCounter.count("pausing " + reason);
       U = VMState.Pausing;
+      profile && $.ctx.pauseMethodTimeline();
     }
 
     stop() {
@@ -1335,6 +1337,8 @@ module J2ME {
             r = fn.apply(this, arguments);
         }
         if (U) {
+          assert(ctx.paused, "context is paused");
+
           if (methodInfo.isNative) {
             // A fake frame that just returns is pushed so when the ctx resumes from the unwind
             // the frame will be popped triggering a leaveMethodTimeline.


### PR DESCRIPTION
This WIP "pauses" the profiler's method timeline while a context is blocked on asynchronous resolution of a method, so it's easier to distinguish between async methods that block for a long time and methods that are themselves expensive.

WIP for cleanup, because I'd like to ponder the implementation approach a bit more, and possibly to implement aggregation of method counts/times across threads, which would make that information more useful. I may also spin off a change or two into a separate branch.
