### PR TITLE
trace aggregate method timeline statistics

### DIFF
--- a/main.js
+++ b/main.js
@@ -200,7 +200,7 @@ function stopAndSaveTimeline() {
       snapshots[i].traceStatistics(writer, 1); // Don't trace any totals below 1 ms.
     }
     // Trace Aggregate Method Statistics
-    writer.writeLn("Aggregate Method Timeline Statistics:");
+    writer.writeLn("Timeline Statistics: All Threads");
     var methodSnapshots = snapshots.slice(2);
     new Shumway.Tools.Profiler.TimelineBufferSnapshotSet(methodSnapshots).traceStatistics(writer, 1);
     // Trace Events

--- a/main.js
+++ b/main.js
@@ -199,6 +199,9 @@ function stopAndSaveTimeline() {
       writer.writeLn("Timeline Statistics: " + i);
       snapshots[i].traceStatistics(writer, 1); // Don't trace any totals below 1 ms.
     }
+    // Trace Aggregate Statistics
+    writer.writeLn("Timeline Aggregate Statistics:");
+    new Shumway.Tools.Profiler.TimelineBufferSnapshotSet(snapshots).traceStatistics(writer, 1);
     // Trace Events
     for (var i = 0; i < snapshots.length; i++) {
       writer.writeLn("Timeline Events: " + i);

--- a/main.js
+++ b/main.js
@@ -199,9 +199,10 @@ function stopAndSaveTimeline() {
       writer.writeLn("Timeline Statistics: " + i);
       snapshots[i].traceStatistics(writer, 1); // Don't trace any totals below 1 ms.
     }
-    // Trace Aggregate Statistics
-    writer.writeLn("Timeline Aggregate Statistics:");
-    new Shumway.Tools.Profiler.TimelineBufferSnapshotSet(snapshots).traceStatistics(writer, 1);
+    // Trace Aggregate Method Statistics
+    writer.writeLn("Aggregate Method Timeline Statistics:");
+    var methodSnapshots = snapshots.slice(2);
+    new Shumway.Tools.Profiler.TimelineBufferSnapshotSet(methodSnapshots).traceStatistics(writer, 1);
     // Trace Events
     for (var i = 0; i < snapshots.length; i++) {
       writer.writeLn("Timeline Events: " + i);
@@ -439,6 +440,8 @@ window.onload = function() {
 
 function requestTimelineBuffers(fn) {
   if (J2ME.timeline) {
+    // If you change the position at which method timelines begin in this array,
+    // then also update the method timeline aggregation in stopAndSaveTimeline.
     var activeTimeLines = [
       J2ME.threadTimeline,
       J2ME.timeline,

--- a/shumway/profiler/timelineFrame.ts
+++ b/shumway/profiler/timelineFrame.ts
@@ -218,7 +218,7 @@ module Shumway.Tools.Profiler {
       return depth;
     }
 
-    public calculateStatistics() {
+    public calculateStatistics(): TimelineFrameStatistics [] {
       var statistics = this.statistics = [];
       function visit(frame: TimelineFrame) {
         if (frame.kind) {
@@ -232,6 +232,7 @@ module Shumway.Tools.Profiler {
         }
       }
       visit(this);
+      return this.statistics;
     }
 
     public traceStatistics(writer: IndentingWriter, minTime: number = 0.0001) {
@@ -282,4 +283,32 @@ module Shumway.Tools.Profiler {
     }
   }
 
+  export class TimelineBufferSnapshotSet extends TimelineBufferSnapshot {
+    constructor (public snapshots: TimelineBufferSnapshot []) {
+      super(null);
+    }
+
+    public calculateStatistics(): TimelineFrameStatistics [] {
+      var snapshots = this.snapshots;
+      var aggregateStats = {};
+
+      for (var i = 0; i < snapshots.length; i++) {
+        var snapshot = snapshots[i];
+        var statistics = snapshot.statistics || snapshot.calculateStatistics();
+
+        for (var j = 0; j < statistics.length; j++) {
+          var stat = statistics[j];
+          if (stat) {
+            var name = stat.kind ? stat.kind.name : "?";
+            var aggregateStat = aggregateStats[name] = aggregateStats[name] || new TimelineFrameStatistics(stat.kind);
+            aggregateStat.count += stat.count;
+            aggregateStat.selfTime += stat.selfTime;
+            aggregateStat.totalTime += stat.totalTime;
+          }
+        }
+      }
+
+      return this.statistics = Object.keys(aggregateStats).map(function (key) { return aggregateStats[key] });
+    }
+  }
 }


### PR DESCRIPTION
This branch reports aggregate (in addition to per-thread) method timeline statistics when PROFILE=2|3, so you can see the overall cost of methods across all the threads in which they're invoked. For example, when profiling warm startup of a complex midlet, I see that `java/lang/Object.wait.(J)V` is called from a number of different threads:

```
java/lang/Object.wait.(J)V: count: 1, self: 1961.835 ms, total: 1961.835 ms.
java/lang/Object.wait.(J)V: count: 2, self: 1956.661 ms, total: 1956.661 ms.
java/lang/Object.wait.(J)V: count: 3, self: 1102.677 ms, total: 1102.677 ms.
java/lang/Object.wait.(J)V: count: 4, self: 1141.161 ms, total: 1141.161 ms.
java/lang/Object.wait.(J)V: count: 2, self: 1827.515 ms, total: 1827.515 ms.
java/lang/Object.wait.(J)V: count: 1, self: 1961.270 ms, total: 1961.270 ms.
java/lang/Object.wait.(J)V: count: 5, self: 1956.100 ms, total: 1956.100 ms.
java/lang/Object.wait.(J)V: count: 1, self: 1961.218 ms, total: 1961.218 ms.
java/lang/Object.wait.(J)V: count: 1, self: 1961.171 ms, total: 1961.171 ms.
java/lang/Object.wait.(J)V: count: 1, self: 1961.152 ms, total: 1961.152 ms.
java/lang/Object.wait.(J)V: count: 1, self: 1961.056 ms, total: 1961.056 ms.
java/lang/Object.wait.(J)V: count: 1, self: 836.142 ms, total: 836.142 ms.
java/lang/Object.wait.(J)V: count: 1, self: 1960.920 ms, total: 1960.920 ms.
java/lang/Object.wait.(J)V: count: 1, self: 225.098 ms, total: 225.098 ms.
java/lang/Object.wait.(J)V: count: 3, self: 498.602 ms, total: 498.602 ms.
java/lang/Object.wait.(J)V: count: 1, self: 1114.266 ms, total: 1114.266 ms.
java/lang/Object.wait.(J)V: count: 1, self: 1115.048 ms, total: 1115.048 ms.
java/lang/Object.wait.(J)V: count: 2, self: 863.410 ms, total: 863.410 ms.
java/lang/Object.wait.(J)V: count: 1, self: 135.771 ms, total: 135.771 ms.
java/lang/Object.wait.(J)V: count: 1, self: 2.312 ms, total: 2.312 ms.
java/lang/Object.wait.(J)V: count: 1, self: 3.024 ms, total: 3.024 ms.
```

This branch enables me to see the aggregate count/cost of that method (although, until #1565, the "cost" in this case will be mostly time spent waiting for the thread to resume):

```
java/lang/Object.wait.(J)V: count: 35, self: 26506.410 ms, total: 26506.410 ms.
```
