### PR TITLE
sort by self time descending

### DIFF
--- a/shumway/profiler/timelineFrame.ts
+++ b/shumway/profiler/timelineFrame.ts
@@ -243,9 +243,9 @@ module Shumway.Tools.Profiler {
           s.push(this.statistics[i]);
         }
       }
-      // Sort by self time.
+      // Sort by self time descending, so expensive events are more prominent.
       s.sort(function (a, b) {
-        return a.selfTime - b.selfTime;
+        return b.selfTime - a.selfTime;
       })
       for (var i = 0; i < s.length; i++) {
         var statistic = s[i];


### PR DESCRIPTION
Reversing the sort order makes the most expensive methods the most prominent ones:

```
Timeline Statistics: 3
java/lang/Object.wait.(J)V: count: 1, self: 1844.965 ms, total: 1844.965 ms.
…
com/sun/midp/main/CldcMIDletSuiteLoader.startSuite.()V: count: 1, self: 0.016 ms, total: 1845.145 ms.
```
