### PR TITLE
pre-allocate circular buffers to avoid expensive allocations during profiling

### DIFF
--- a/shumway/profiler/timelineBuffer.ts
+++ b/shumway/profiler/timelineBuffer.ts
@@ -76,8 +76,10 @@ module Shumway.Tools.Profiler {
       this._data = [];
       this._kinds = [];
       this._kindNameMap = Object.create(null);
-      this._marks = TimelineBuffer.preAllocInt32ArrayBuffers.pop() || new Shumway.CircularBuffer(Int32Array, BUFFER_SIZE);
-      this._times = TimelineBuffer.preAllocFloat64ArrayBuffers.pop() || new Shumway.CircularBuffer(Float64Array, BUFFER_SIZE);
+      this._marks = TimelineBuffer.preAllocInt32ArrayBuffers.pop() ||
+                    new Shumway.CircularBuffer(Int32Array, TimelineBuffer.BUFFER_SIZE);
+      this._times = TimelineBuffer.preAllocFloat64ArrayBuffers.pop() ||
+                    new Shumway.CircularBuffer(Float64Array, TimelineBuffer.BUFFER_SIZE);
     }
 
     private _getKindId(name: string):number {
@@ -304,7 +306,7 @@ module Shumway.Tools.Profiler {
 
   // Pre-allocate some circular buffers to avoid expensive allocations during profiling.
   for (var i = 0; i < 64; i++) {
-    TimelineBuffer.preAllocInt32ArrayBuffers.push(new Shumway.CircularBuffer(Int32Array, BUFFER_SIZE));
-    TimelineBuffer.preAllocFloat64ArrayBuffers.push(new Shumway.CircularBuffer(Float64Array, BUFFER_SIZE));
+    TimelineBuffer.preAllocInt32ArrayBuffers.push(new Shumway.CircularBuffer(Int32Array, TimelineBuffer.BUFFER_SIZE));
+    TimelineBuffer.preAllocFloat64ArrayBuffers.push(new Shumway.CircularBuffer(Float64Array, TimelineBuffer.BUFFER_SIZE));
   }
 }

--- a/shumway/profiler/timelineBuffer.ts
+++ b/shumway/profiler/timelineBuffer.ts
@@ -35,6 +35,9 @@ module Shumway.Tools.Profiler {
     static MAX_KINDID = 0xffff;
     static MAX_DATAID = 0x7fff;
 
+    static preAllocInt32ArrayBuffers: Shumway.CircularBuffer [] = [];
+    static preAllocFloat64ArrayBuffers: Shumway.CircularBuffer [] = [];
+
     private _depth: number;
     private _data: any [];
     private _kinds: TimelineItemKind [];
@@ -69,8 +72,8 @@ module Shumway.Tools.Profiler {
       this._data = [];
       this._kinds = [];
       this._kindNameMap = Object.create(null);
-      this._marks = new Shumway.CircularBuffer(Int32Array, 20);
-      this._times = new Shumway.CircularBuffer(Float64Array, 20);
+      this._marks = TimelineBuffer.preAllocInt32ArrayBuffers.pop() || new Shumway.CircularBuffer(Int32Array, 20);
+      this._times = TimelineBuffer.preAllocFloat64ArrayBuffers.pop() || new Shumway.CircularBuffer(Float64Array, 20);
     }
 
     private _getKindId(name: string):number {
@@ -295,4 +298,9 @@ module Shumway.Tools.Profiler {
     }
   }
 
+  // Pre-allocate some circular buffers to avoid expensive allocations during profiling.
+  for (var i = 0; i < 64; i++) {
+    TimelineBuffer.preAllocInt32ArrayBuffers.push(new Shumway.CircularBuffer(Int32Array, 20));
+    TimelineBuffer.preAllocFloat64ArrayBuffers.push(new Shumway.CircularBuffer(Float64Array, 20));
+  }
 }

--- a/shumway/profiler/timelineBuffer.ts
+++ b/shumway/profiler/timelineBuffer.ts
@@ -35,6 +35,10 @@ module Shumway.Tools.Profiler {
     static MAX_KINDID = 0xffff;
     static MAX_DATAID = 0x7fff;
 
+    // The size of the circular buffers.  If you've had timelines overflow,
+    // then try changing this to 23.
+    static BUFFER_SIZE = 20;
+
     static preAllocInt32ArrayBuffers: Shumway.CircularBuffer [] = [];
     static preAllocFloat64ArrayBuffers: Shumway.CircularBuffer [] = [];
 
@@ -72,8 +76,8 @@ module Shumway.Tools.Profiler {
       this._data = [];
       this._kinds = [];
       this._kindNameMap = Object.create(null);
-      this._marks = TimelineBuffer.preAllocInt32ArrayBuffers.pop() || new Shumway.CircularBuffer(Int32Array, 20);
-      this._times = TimelineBuffer.preAllocFloat64ArrayBuffers.pop() || new Shumway.CircularBuffer(Float64Array, 20);
+      this._marks = TimelineBuffer.preAllocInt32ArrayBuffers.pop() || new Shumway.CircularBuffer(Int32Array, BUFFER_SIZE);
+      this._times = TimelineBuffer.preAllocFloat64ArrayBuffers.pop() || new Shumway.CircularBuffer(Float64Array, BUFFER_SIZE);
     }
 
     private _getKindId(name: string):number {
@@ -300,7 +304,7 @@ module Shumway.Tools.Profiler {
 
   // Pre-allocate some circular buffers to avoid expensive allocations during profiling.
   for (var i = 0; i < 64; i++) {
-    TimelineBuffer.preAllocInt32ArrayBuffers.push(new Shumway.CircularBuffer(Int32Array, 20));
-    TimelineBuffer.preAllocFloat64ArrayBuffers.push(new Shumway.CircularBuffer(Float64Array, 20));
+    TimelineBuffer.preAllocInt32ArrayBuffers.push(new Shumway.CircularBuffer(Int32Array, BUFFER_SIZE));
+    TimelineBuffer.preAllocFloat64ArrayBuffers.push(new Shumway.CircularBuffer(Float64Array, BUFFER_SIZE));
   }
 }


### PR DESCRIPTION
*TimelineBuffer* initializes itself lazily, including creating two circular buffers (one wrapping an *Int32Array* and another wrapping a *Float64Array*). That can skew results when a method being measured by one timeline triggers the creation of another timeline, since occasionally the browser takes a while to create those typed arrays (particularly the *Float64Array* one).

In particular, when profiling a midlet that creates many threads on desktop, *Thread.start0* is one of the most expensive methods in the aggregate method statistics produced by #1569:

> java/lang/Thread.start0.()V: count: 11, self: 94.898 ms, total: 94.898 ms.

But most of the cost is because it creates a new *Context*, which creates a new *TimelineBuffer*, and then starts the context, which enters *org/mozilla/internal/Sys.runThread.(Ljava/lang/Thread;)V* in the new context's timeline, triggering initialization of the timeline (and potentially expensive allocations of the circular buffers). So the cost is actually excise, overhead from profiling, rather than an accurate reflection of the cost of the method.

This branch frontloads that cost during startup by pre-allocating a set of circular buffers for the timeline buffers to use, so it doesn't affect the cost of such methods. With this change, *Thread.start0* is cheap:

> java/lang/Thread.start0.()V: count: 11, self: 2.800 ms, total: 2.800 ms.
