### PR TITLE
Create an AMS module for tracking AMS isolate

### DIFF
--- a/midp/midp.js
+++ b/midp/midp.js
@@ -180,17 +180,53 @@ var MIDP = (function() {
     return $.ctx.runtime.isolate.id;
   };
 
-  var AMSIsolateId;
+  var AMS = (function() {
+    var isolateId = -1;
+
+    function set(id) {
+      isolateId = id;
+    }
+
+    function reset() {
+      isolateId = -1;
+    }
+
+    function get() {
+      return isolateId;
+    }
+
+    function isAMSIsolate(id) {
+      return (id === isolateId);
+    }
+
+    function sendNativeEventToAMSIsolate(e) {
+      if (-1 === isolateId) {
+        console.warn("Dropping native event sent to AMS isolate");
+        return;
+      }
+
+      sendNativeEvent(e, isolateId);
+    }
+
+    return {
+      set: set,
+      get: get,
+      reset: reset,
+      isAMSIsolate: isAMSIsolate,
+      sendNativeEventToAMSIsolate: sendNativeEventToAMSIsolate,
+    }
+  })();
+
   Native["com/sun/midp/main/MIDletSuiteUtils.registerAmsIsolateId.()V"] = function() {
-    AMSIsolateId = $.ctx.runtime.isolate.id;
+    AMS.set($.ctx.runtime.isolate.id);
   };
 
   Native["com/sun/midp/main/MIDletSuiteUtils.getAmsIsolateId.()I"] = function() {
-    return AMSIsolateId;
+    return AMS.get();
   };
 
   Native["com/sun/midp/main/MIDletSuiteUtils.isAmsIsolate.()Z"] = function() {
-    return AMSIsolateId == $.ctx.runtime.isolate.id ? 1 : 0;
+    return AMS.isAMSIsolate($.ctx.runtime.isolate.id) ? 1 : 0;
   };
 
   // This function is called before a MIDlet is created (in MIDletStateListener::midletPreStart).
@@ -699,7 +735,13 @@ var MIDP = (function() {
       return;
     }
 
-    console.info("Isolate stops with code " + code + " and reason " + reason);
+    var isolateId = $.ctx.runtime.isolate.id;
+    console.info("Isolate " + isolateId + " stops with code " + code + " and reason " + reason);
+
+    if (AMS.isAMSIsolate(isolateId)) {
+      AMS.reset();
+    }
+
     if (!pendingMIDletUpdate) {
       exit();
       return;
@@ -789,9 +831,9 @@ var MIDP = (function() {
   }
 
   function sendExecuteMIDletEvent() {
-    sendNativeEvent({
+    AMS.sendNativeEventToAMSIsolate({
       type: NATIVE_MIDLET_EXECUTE_REQUEST,
-    }, AMSIsolateId);
+    });
   }
 
   function sendDestroyMIDletEvent(midletClassName) {


### PR DESCRIPTION
Warn when sending events to AMS if they have no chance of being processed. When the AMS isolate stops, update the information that we present about the AMS isolate.

This fixes issues that came up during the work on FG MIDlet launching. It's unlikely to have visible impact, but it will ease debugging if these issues come up again.