### PR TITLE
Implement `AppProxy` natives

### DIFF
--- a/midp/content.js
+++ b/midp/content.js
@@ -69,7 +69,6 @@ var Content = (function() {
     return 0;
   };
 
-  addUnimplementedNative("com/sun/j2me/content/AppProxy.midletIsRemoved.(ILjava/lang/String;)V");
   addUnimplementedNative("com/sun/j2me/content/AppProxy.platformFinish0.(I)Z", 0);
 
   var invocation = null;

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -1211,6 +1211,36 @@ var MIDP = (function() {
     console.warn("NetworkConnectionBase.initializeInternal.()V not implemented");
   };
 
+  var runningSuites = new Map();
+  Native["com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V"] = function(suiteId, className) {
+    var suite = runningSuites.get(suiteId);
+    if (!suite) {
+      suite = new Set();
+      runningSuites.set(suiteId, suite);
+    }
+
+    suite.add(className);
+  };
+
+  Native["com/sun/j2me/content/AppProxy.midletIsRemoved.(ILjava/lang/String;)V"] = function(suiteId, className) {
+    var suite = runningSuites.get(suiteId);
+    if (suite) {
+      suite.delete(className);
+      if (suite.size === 0) {
+        runningSuites.delete(suiteId);
+      }
+    }
+  }
+
+  Native["com/sun/j2me/content/AppProxy.isMidletRunning.(ILjava/lang/String;)V"] = function(suiteId, className) {
+    var suite = runningSuites.get(suiteId);
+    return suite && suite.has(className);
+  }
+
+  Native["com/sun/j2me/content/AppProxy.isSuiteRunning.(I)V"] = function(suiteId) {
+    return runningSuites.has(suiteId);
+  }
+
   addUnimplementedNative("com/nokia/mid/ui/VirtualKeyboard.hideOpenKeypadCommand.(Z)V");
   addUnimplementedNative("com/nokia/mid/ui/VirtualKeyboard.suppressSizeChanged.(Z)V");
 

--- a/native.js
+++ b/native.js
@@ -874,10 +874,6 @@ Native["com/sun/cldc/i18n/j2me/UTF_8_Writer.sizeOf.([CII)I"] = function(cbuf, of
   return outputCount;
 };
 
-Native["com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V"] = function(suiteId, className) {
-  console.warn("com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V not implemented");
-};
-
 Native["com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V"] = function(content) {
     var fileName = J2ME.fromJavaString(content);
 


### PR DESCRIPTION
Implement `AppProxy.midletIsAdded`, `AppProxy.midletIsRemoved`,
`AppProxy.isMidletRunning`, and `AppProxy.isSuiteRunning`. I implemented
these as part of the FG MIDlet work. They don't seem to be used that
much by popular MIDlets, but since I have the implementation sitting
around I figured I'd submit the PR.