### PR TITLE
Automatically download SpiderMonkey in build_tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - npm install casperjs
   - npm install typescript
-  - wget -P /tmp/j2me.js -N https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/37.0b7-candidates/build1/jsshell-linux-x86_64.zip
-  - unzip -d /tmp/js /tmp/j2me.js/jsshell-linux-x86_64.zip
   - export PATH=$PATH:/tmp/js
 script:
   - make test
@@ -16,7 +14,6 @@ sudo: false
 cache:
   directories:
     - node_modules
-    - /tmp/j2me.js
     - build_tools
 notifications:
   irc:

--- a/Makefile
+++ b/Makefile
@@ -207,19 +207,19 @@ PATH := build_tools/slimerjs-$(SLIMERJS_VERSION):${PATH}
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 ifeq ($(UNAME_S),Linux)
-	XULRUNNER_PLATFORM=linux-$(UNAME_M)
+	PLATFORM=linux-$(UNAME_M)
 	XULRUNNER_PATH=xulrunner/xulrunner
 endif
 ifeq ($(UNAME_S),Darwin)
-	XULRUNNER_PLATFORM=mac
+	PLATFORM=mac
 	XULRUNNER_PATH=XUL.framework/Versions/Current/xulrunner
 endif
 ifneq (,$(findstring MINGW,$(uname_S)))
-	XULRUNNER_PLATFORM=win32
+	PLATFORM=win32
 	XULRUNNER_PATH=xulrunner/xulrunner
 endif
 ifneq (,$(findstring CYGWIN,$(uname_S)))
-	XULRUNNER_PLATFORM=win32
+	PLATFORM=win32
 	XULRUNNER_PATH=xulrunner/xulrunner
 endif
 
@@ -234,8 +234,8 @@ build_tools/slimerjs-$(SLIMERJS_VERSION): build_tools/.slimerjs_version
 
 build_tools/$(XULRUNNER_PATH): build_tools/.xulrunner_version
 	rm -rf build_tools/XUL* build_tools/xul*
-	wget -P build_tools -N https://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/$(XULRUNNER_VERSION)/runtimes/xulrunner-$(XULRUNNER_VERSION).en-US.$(XULRUNNER_PLATFORM).tar.bz2
-	tar x -C build_tools -f build_tools/xulrunner-$(XULRUNNER_VERSION).en-US.$(XULRUNNER_PLATFORM).tar.bz2 -m
+	wget -P build_tools -N https://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/$(XULRUNNER_VERSION)/runtimes/xulrunner-$(XULRUNNER_VERSION).en-US.$(PLATFORM).tar.bz2
+	tar x -C build_tools -f build_tools/xulrunner-$(XULRUNNER_VERSION).en-US.$(PLATFORM).tar.bz2 -m
 
 build_tools/soot-trunk.jar: build_tools/.soot_version
 	rm -f build_tools/soot-trunk.jar
@@ -251,8 +251,8 @@ JS=build_tools/spidermonkey/js
 
 $(JS): build_tools/.spidermonkey_version
 	rm -rf build_tools/spidermonkey build_tools/jsshell*
-	wget -P build_tools -N https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/37.0b7-candidates/build1/jsshell-linux-x86_64.zip
-	unzip -o -d build_tools/spidermonkey build_tools/jsshell-linux-x86_64.zip
+	wget -P build_tools -N https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/$(SPIDERMONKEY_VERSION)-candidates/build1/jsshell-$(PLATFORM).zip
+	unzip -o -d build_tools/spidermonkey build_tools/jsshell-$(PLATFORM).zip
 	touch $(JS)
 
 $(PREPROCESS_DESTS): $(PREPROCESS_SRCS) .checksum

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ build_tools/$(XULRUNNER_PATH): build_tools/.xulrunner_version
 
 build_tools/soot-trunk.jar: build_tools/.soot_version
 	rm -f build_tools/soot-trunk.jar
-	wget -P build_tools https://github.com/marco-c/soot/releases/download/soot-25Mar2015/soot-trunk.jar
+	wget -P build_tools https://github.com/marco-c/soot/releases/download/soot-$(SOOT_VERSION)/soot-trunk.jar
 	touch build_tools/soot-trunk.jar
 
 build_tools/closure.jar: build_tools/.closure_compiler_version

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ SPIDERMONKEY_VERSION=37.0b7
 OLD_SPIDERMONKEY_VERSION := $(shell [ -f build_tools/.spidermonkey_version ] && cat build_tools/.spidermonkey_version)
 $(shell [ "$(SPIDERMONKEY_VERSION)" != "$(OLD_SPIDERMONKEY_VERSION)" ] && echo $(SPIDERMONKEY_VERSION) > build_tools/.spidermonkey_version)
 
-PATH := build_tools/slimerjs-$(SLIMERJS_VERSION):${PATH}
+PATH := build_tools/spidermonkey:build_tools/slimerjs-$(SLIMERJS_VERSION):${PATH}
 
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
@@ -293,17 +293,17 @@ j2me: bld/j2me.js bld/jsc.js
 aot: bld/classes.jar.js
 bld/classes.jar.js: java/classes.jar bld/jsc.js aot-methods.txt build_tools/closure.jar $(JS) .checksum
 	@echo "Compiling ..."
-	$(JS) bld/jsc.js -cp java/classes.jar -d -jf java/classes.jar -mff aot-methods.txt > bld/classes.jar.js
+	js bld/jsc.js -cp java/classes.jar -d -jf java/classes.jar -mff aot-methods.txt > bld/classes.jar.js
 ifeq ($(RELEASE),1)
 	java -jar build_tools/closure.jar --warning_level $(CLOSURE_WARNING_LEVEL) --language_in ECMASCRIPT5 -O SIMPLE bld/classes.jar.js > bld/classes.jar.cc.js \
 		&& mv bld/classes.jar.cc.js bld/classes.jar.js
 endif
 
 bld/tests.jar.js: tests/tests.jar bld/jsc.js $(JS) aot-methods.txt
-	$(JS) bld/jsc.js -cp java/classes.jar tests/tests.jar -d -jf tests/tests.jar -mff aot-methods.txt > bld/tests.jar.js
+	js bld/jsc.js -cp java/classes.jar tests/tests.jar -d -jf tests/tests.jar -mff aot-methods.txt > bld/tests.jar.js
 
 bld/program.jar.js: program.jar bld/jsc.js $(JS) aot-methods.txt
-	$(JS) bld/jsc.js -cp java/classes.jar program.jar -d -jf program.jar -mff aot-methods.txt > bld/program.jar.js
+	js bld/jsc.js -cp java/classes.jar program.jar -d -jf program.jar -mff aot-methods.txt > bld/program.jar.js
 
 shumway: bld/shumway.js
 bld/shumway.js: $(SHUMWAY_SRCS)


### PR DESCRIPTION
We're currently downloading SpiderMonkey only on Travis (via .travis.yml). Downloading it in the Makefile makes it easier for developers (for example, it'd avoid problems like https://github.com/mozilla/j2me.js/issues/1623).