### PR TITLE
Allow running a subset of the basic unit tests without launching a MIDlet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 certs/j2se_main.ks
 certs/j2se_test.ks
 tests/Testlets.java
+tests/MIDletTestlets.java
 output/
 bld/
 build_tools/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VERBOSE ?= 0
 export VERBOSE
 
 # An extra configuration script to load.  Use this to configure the project
-# to run a particular midlet.  By default, it runs the test midlet RunTests.
+# to run a particular midlet.  By default, it runs the test midlet RunTestsMIDlet.
 CONFIG ?= config/runtests.js
 export CONFIG
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ index.html is a webapp that runs j2me.js. The URL parameters you pass to index.h
 You can specify URL parameters to override the configuration. See the full list of parameters at config/urlparams.js.
 
 * `main` - default is `com/sun/midp/main/MIDletSuiteLoader`
-* `midletClassName` - must be set to the main class to run. Only valid when default `main` parameter is used. Defaults to `RunTests`
+* `midletClassName` - must be set to the main class to run. Only valid when default `main` parameter is used. Defaults to `RunTestsMIDlet`
 * `autosize` - if set to `1`, j2me app will fill the page.
 * `gamepad` - if set to `1`, gamepad will be visible/available.
 
@@ -86,7 +86,7 @@ If you want to pass additional [casperJS command line options](http://docs.slime
 
 gfx tests use image comparison; a reference image is provided with the test and the output of the test must match the reference image. The output is allowed to differ from the reference image by a number of pixels specified in automation.js.
 
-The main set of unit tests that automation.js runs is the set covered by the RunTests MIDlet. The full list of RunTests tests available in the tests/Testlets.java generated file. RunTests runs a number of "Testlets" (Java classes that implement the `Testlet` interface).
+The main set of unit tests that automation.js runs is the set covered by the RunTests class. The full list of RunTests tests available in the tests/Testlets.java generated file. RunTests runs a number of "Testlets" (Java classes that implement the `Testlet` interface). Testlets that require to be executed in a MIDlet environment (classes that implement the `MIDletTestlet` interface) are run by RunTestsMIDlet. The full list of these tests is available in the tests/MIDletTestlets.java generated file.
 
 ### Running a single test
 

--- a/config/runtests.js
+++ b/config/runtests.js
@@ -1,3 +1,3 @@
 config.jars = "tests/tests.jar";
 config.jad = "tests/runtests.jad";
-config.midletClassName = "RunTests";
+config.midletClassName = "RunTestsMIDlet";

--- a/index.js.in
+++ b/index.js.in
@@ -8,7 +8,7 @@
  */
 (function() {
   var loadingPromises = [];
-  if (config.midletClassName === "RunTests" ||
+  if (config.midletClassName === "RunTestsMIDlet" ||
       config.midletClassName.startsWith("tests.midlets")) {
     loadingPromises.push(loadScript("tests/contacts.js"),
                          loadScript("tests/index.js"),

--- a/libs/fs-init.js
+++ b/libs/fs-init.js
@@ -25,7 +25,7 @@ var initialFiles = [
 var initFS = new Promise(function(resolve, reject) {
   fs.init(resolve);
 }).then(function() {
-  if (typeof config !== "undefined" && config.midletClassName == "RunTests") {
+  if (typeof config !== "undefined" && config.midletClassName == "RunTestsMIDlet") {
     initialDirs.push("/tcktestdir");
   }
 
@@ -35,7 +35,7 @@ var initFS = new Promise(function(resolve, reject) {
 }).then(function() {
   var filePromises = [];
 
-  if (typeof config !== "undefined" && config.midletClassName == "RunTests") {
+  if (typeof config !== "undefined" && config.midletClassName == "RunTestsMIDlet") {
     initialFiles.push({ sourcePath: "certs/_test.ks", targetPath: "/_test.ks" });
   }
 

--- a/main.js
+++ b/main.js
@@ -253,7 +253,7 @@ function start() {
 }
 
 // If we're not running a MIDlet, we need to wait everything to be loaded.
-if (!config.midletClassName || config.midletClassName == "RunTestsMIDlet") {
+if (!config.midletClassName) {
   loadingPromises = loadingPromises.concat(loadingMIDletPromises);
 }
 

--- a/main.js
+++ b/main.js
@@ -253,7 +253,7 @@ function start() {
 }
 
 // If we're not running a MIDlet, we need to wait everything to be loaded.
-if (!config.midletClassName || config.midletClassName == "RunTests") {
+if (!config.midletClassName || config.midletClassName == "RunTestsMIDlet") {
   loadingPromises = loadingPromises.concat(loadingMIDletPromises);
 }
 

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -248,7 +248,7 @@ var MIDP = (function() {
     var value;
     switch (J2ME.fromJavaString(key)) {
       case "com.sun.midp.publickeystore.WebPublicKeyStore":
-        if (config.midletClassName == "RunTests" ||
+        if (config.midletClassName == "RunTestsMIDlet" ||
             config.midletClassName.startsWith("benchmark")) {
           value = "_test.ks";
         } else {

--- a/polyfill/chrome_polyfills.js
+++ b/polyfill/chrome_polyfills.js
@@ -1,6 +1,6 @@
 'use strict';
 
-if (config.midletClassName !== "RunTests" && navigator && !navigator.mozContacts) {
+if (config.midletClassName !== "RunTestsMIDlet" && navigator && !navigator.mozContacts) {
   navigator.mozContacts = {
     getAll: function () {
       var req = {};

--- a/tests/Harness.java
+++ b/tests/Harness.java
@@ -1,0 +1,77 @@
+/* vim: set filetype=java shiftwidth=4 tabstop=4 autoindent cindent expandtab : */
+
+import gnu.testlet.*;
+
+import com.sun.cldchi.jvm.JVM;
+import javax.microedition.lcdui.Display;
+import javax.microedition.lcdui.Form;
+import javax.microedition.midlet.*;
+import java.lang.Exception;
+import java.util.Vector;
+
+public class Harness extends TestHarness {
+    private String testName;
+    private int testNumber = 0;
+    private String testNote = null;
+    private int pass = 0;
+    private int fail = 0;
+    private int knownFail = 0;
+    private int unknownPass = 0;
+
+    public Harness(String note, Display d) {
+        super(d);
+        this.testName = note;
+    }
+
+    public void setNote(String note) {
+        testNote = note;
+    }
+
+    public void debug(String msg) {
+        System.out.println(testName + "-" + testNumber + ": " + msg + ((testNote != null) ? (" [" + testNote + "]") : ""));
+    }
+
+        public void check(boolean ok) {
+            if (ok) {
+                ++pass;
+            }
+            else {
+                ++fail;
+                debug("fail");
+            }
+            ++testNumber;
+            setNote(null);
+        }
+
+        public void todo(boolean ok) {
+            if (ok) {
+                ++unknownPass;
+                debug("unknown pass");
+            }
+            else
+                ++knownFail;
+            ++testNumber;
+            setNote(null);
+        }
+
+        public void report() {
+            System.out.println(testName + ": " + pass + " pass, " + fail + " fail, " + knownFail + " known fail, " +
+                               unknownPass + " unknown pass");
+        }
+
+        public int passed() {
+            return pass;
+        }
+
+        public int failed() {
+            return fail;
+        }
+
+        public int knownFailed() {
+            return knownFail;
+        }
+
+        public int unknownPassed() {
+            return unknownPass;
+        }
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -56,7 +56,14 @@ Testlets.java: $(SRCS) $(JASMIN_SRCS) Makefile
 	@echo "  null};" >> $@
 	@echo "};" >> $@
 
-tests.jar: $(SRCS) $(JASMIN_SRCS) Testlets.java
+MIDletTestlets.java: $(SRCS) Makefile
+	@echo "public class MIDletTestlets {" > $@
+	@echo "  static String[] list = {" >> $@
+	@grep "implements MIDletTestlet" $(SRCS) | sed -e "s/^.\///" -e "s/\.java.*//" -e "s/\(.*\)/\"\1\",/" >> $@
+	@echo "  null};" >> $@
+	@echo "};" >> $@
+
+tests.jar: $(SRCS) $(JASMIN_SRCS) Testlets.java MIDletTestlets.java
 	rm -rf build
 	mkdir build
 	# Build the buildtime support classes in-place, not in ./build, so they aren't available at runtime.

--- a/tests/RunTests.java
+++ b/tests/RunTests.java
@@ -14,7 +14,7 @@ public class RunTests {
 
         System.out.println("Running " + name);
 
-        Harness harness = new Harness(name, null);
+        j2mejsTestHarness harness = new j2mejsTestHarness(name, null);
 
         Class c = null;
         try {

--- a/tests/RunTests.java
+++ b/tests/RunTests.java
@@ -20,22 +20,19 @@ public class RunTests {
         try {
             c = Class.forName(name);
         } catch (Exception e) {
-            System.err.println(e);
-            harness.fail("Can't load test");
+            harness.fail("Can't load test: " + e);
         }
         Object obj = null;
         try {
             obj = c.newInstance();
         } catch (Exception e) {
-            System.err.println(e);
-            harness.fail("Can't instantiate test");
+            harness.fail("Can't instantiate test: " + e);
         }
         Testlet t = (Testlet) obj;
         try {
             t.test(harness);
         } catch (Exception e) {
-            System.err.println(e);
-            harness.fail("Test threw an unexpected exception");
+            harness.fail("Test threw an unexpected exception: " + e);
         }
         harness.report();
         boolean classPassed = true;

--- a/tests/RunTestsMIDlet.java
+++ b/tests/RunTestsMIDlet.java
@@ -26,22 +26,19 @@ public class RunTestsMIDlet extends MIDlet {
         try {
             c = Class.forName(name);
         } catch (Exception e) {
-            System.err.println(e);
-            harness.fail("Can't load test");
+            harness.fail("Can't load test: " + e);
         }
         Object obj = null;
         try {
             obj = c.newInstance();
         } catch (Exception e) {
-            System.err.println(e);
-            harness.fail("Can't instantiate test");
+            harness.fail("Can't instantiate test: " + e);
         }
         Testlet t = (Testlet) obj;
         try {
             t.test(harness);
         } catch (Exception e) {
-            System.err.println(e);
-            harness.fail("Test threw an unexpected exception");
+            harness.fail("Test threw an unexpected exception: " + e);
         }
         harness.report();
         boolean classPassed = true;

--- a/tests/RunTestsMIDlet.java
+++ b/tests/RunTestsMIDlet.java
@@ -19,7 +19,7 @@ public class RunTestsMIDlet extends MIDlet {
 
         Form form = new Form(name);
         Display display = Display.getDisplay(this);
-        Harness harness = new Harness(name, display);
+        j2mejsTestHarness harness = new j2mejsTestHarness(name, display);
         harness.setScreenAndWait(form);
 
         Class c = null;

--- a/tests/com/nokia/mid/ui/TestVirtualKeyboard.java
+++ b/tests/com/nokia/mid/ui/TestVirtualKeyboard.java
@@ -3,7 +3,7 @@
 package com.nokia.mid.ui;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import javax.microedition.lcdui.Canvas;
 import javax.microedition.lcdui.Font;
 import javax.microedition.lcdui.Graphics;
@@ -45,7 +45,7 @@ class TestKeyboardVisibilityListener implements com.nokia.mid.ui.KeyboardVisibil
     }
 }
 
-public class TestVirtualKeyboard extends Canvas implements Testlet {
+public class TestVirtualKeyboard extends Canvas implements MIDletTestlet {
     public int getExpectedPass() { return 9; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/com/sun/midp/io/j2me/http/TestHttpConnection.java
+++ b/tests/com/sun/midp/io/j2me/http/TestHttpConnection.java
@@ -1,11 +1,11 @@
 package com.sun.midp.io.j2me.http;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import java.io.*;
 import javax.microedition.io.*;
 
-public class TestHttpConnection implements Testlet {
+public class TestHttpConnection implements MIDletTestlet {
     public int getExpectedPass() { return 5; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/com/sun/midp/io/j2me/http/TestHttpHeaders.java
+++ b/tests/com/sun/midp/io/j2me/http/TestHttpHeaders.java
@@ -27,7 +27,7 @@
 package com.sun.midp.io.j2me.http;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import java.io.IOException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -39,7 +39,7 @@ import java.io.OutputStream;
 import javax.microedition.io.StreamConnection;
 import javax.microedition.io.Connector;
 
-public class TestHttpHeaders implements Testlet {
+public class TestHttpHeaders implements MIDletTestlet {
     public int getExpectedPass() { return 12; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/com/sun/midp/io/j2me/socket/StressTestSocket.java
+++ b/tests/com/sun/midp/io/j2me/socket/StressTestSocket.java
@@ -1,11 +1,11 @@
 package com.sun.midp.io.j2me.socket;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import java.io.*;
 import javax.microedition.io.*;
 
-public class StressTestSocket implements Testlet {
+public class StressTestSocket implements MIDletTestlet {
     public int getExpectedPass() { return 200; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/com/sun/midp/io/j2me/socket/TestSocket.java
+++ b/tests/com/sun/midp/io/j2me/socket/TestSocket.java
@@ -1,11 +1,11 @@
 package com.sun.midp.io.j2me.socket;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import java.io.*;
 import javax.microedition.io.*;
 
-public class TestSocket implements Testlet {
+public class TestSocket implements MIDletTestlet {
     public int getExpectedPass() { return 12; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/com/sun/midp/io/j2me/storage/TestRandomAccessStream.java
+++ b/tests/com/sun/midp/io/j2me/storage/TestRandomAccessStream.java
@@ -5,9 +5,9 @@ import javax.microedition.io.Connector;
 import javax.microedition.io.file.FileConnection;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 
-public class TestRandomAccessStream implements Testlet {
+public class TestRandomAccessStream implements MIDletTestlet {
     public int getExpectedPass() { return 108; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/com/sun/midp/publickeystore/TestInputOutputStorage.java
+++ b/tests/com/sun/midp/publickeystore/TestInputOutputStorage.java
@@ -1,7 +1,7 @@
 package com.sun.midp.publickeystore;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import javax.microedition.io.Connector;
 import javax.microedition.io.file.FileConnection;
 import javax.microedition.io.*;
@@ -9,7 +9,7 @@ import javax.microedition.io.file.*;
 import java.io.*;
 import com.sun.midp.io.j2me.storage.RandomAccessStream;
 
-public class TestInputOutputStorage implements Testlet {
+public class TestInputOutputStorage implements MIDletTestlet {
     public int getExpectedPass() { return 13; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/com/sun/midp/publickeystore/TestWebPublicKeyStore.java
+++ b/tests/com/sun/midp/publickeystore/TestWebPublicKeyStore.java
@@ -1,7 +1,7 @@
 package com.sun.midp.publickeystore;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 
 import java.util.*;
 import java.io.IOException;
@@ -10,7 +10,7 @@ import com.sun.midp.pki.*;
 import com.sun.midp.security.*;
 import com.sun.midp.main.Configuration;
 
-public class TestWebPublicKeyStore implements Testlet {
+public class TestWebPublicKeyStore implements MIDletTestlet {
     public int getExpectedPass() { return 3; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/com/sun/midp/ssl/TestSSLStreamConnection.java
+++ b/tests/com/sun/midp/ssl/TestSSLStreamConnection.java
@@ -5,14 +5,14 @@ package com.sun.midp.ssl;
 
 import com.sun.midp.publickeystore.WebPublicKeyStore;
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import javax.microedition.io.Connector;
 import javax.microedition.io.StreamConnection;
 
-public class TestSSLStreamConnection implements Testlet {
+public class TestSSLStreamConnection implements MIDletTestlet {
     public int getExpectedPass() { return 203; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/fs/fs-init-async.js
+++ b/tests/fs/fs-init-async.js
@@ -30,7 +30,7 @@ var initialFiles = [
 var initFS = new Promise(function(resolve, reject) {
   fs.init(resolve);
 }).then(function() {
-  if (typeof config !== "undefined" && config.midletClassName == "RunTests") {
+  if (typeof config !== "undefined" && config.midletClassName == "RunTestsMIDlet") {
     initialDirs.push("/tcktestdir");
   }
 
@@ -48,7 +48,7 @@ var initFS = new Promise(function(resolve, reject) {
 }).then(function() {
   var filePromises = [];
 
-  if (typeof config !== "undefined" && config.midletClassName == "RunTests") {
+  if (typeof config !== "undefined" && config.midletClassName == "RunTestsMIDlet") {
     initialFiles.push({ sourcePath: "certs/_test.ks", targetPath: "/_test.ks" });
   }
 

--- a/tests/gnu/testlet/MIDletTestlet.java
+++ b/tests/gnu/testlet/MIDletTestlet.java
@@ -1,0 +1,4 @@
+package gnu.testlet;
+
+public interface MIDletTestlet extends Testlet {
+}

--- a/tests/j2mejsTestHarness.java
+++ b/tests/j2mejsTestHarness.java
@@ -9,7 +9,7 @@ import javax.microedition.midlet.*;
 import java.lang.Exception;
 import java.util.Vector;
 
-public class Harness extends TestHarness {
+public class j2mejsTestHarness extends TestHarness {
     private String testName;
     private int testNumber = 0;
     private String testNote = null;
@@ -18,7 +18,7 @@ public class Harness extends TestHarness {
     private int knownFail = 0;
     private int unknownPass = 0;
 
-    public Harness(String note, Display d) {
+    public j2mejsTestHarness(String note, Display d) {
         super(d);
         this.testName = note;
     }

--- a/tests/javax/microedition/content/TestContentHandler.java
+++ b/tests/javax/microedition/content/TestContentHandler.java
@@ -1,9 +1,9 @@
 package javax.microedition.content;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 
-public class TestContentHandler implements Testlet {
+public class TestContentHandler implements MIDletTestlet {
     public int getExpectedPass() { return 11; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }
@@ -11,7 +11,7 @@ public class TestContentHandler implements Testlet {
     native static void addInvocation(String argument, String action);
 
     void testInvocation(TestHarness th) throws ContentHandlerException {
-        ContentHandlerServer chServer = Registry.getServer("RunTests");
+        ContentHandlerServer chServer = Registry.getServer("RunTestsMIDlet");
 
         Invocation invoc = chServer.getRequest(false);
         th.check(invoc, null, "Invocation is null");
@@ -30,8 +30,8 @@ public class TestContentHandler implements Testlet {
 
     public void test(TestHarness th) {
         try {
-            Registry.getRegistry("RunTests")
-                    .register("RunTests",
+            Registry.getRegistry("RunTestsMIDlet")
+                    .register("RunTestsMIDlet",
                               new String[] { "image/jpeg", "image/png", "image/gif", "audio/amr", "audio/mp3", "video/3gpp", "video/mp4" },
                               null,
                               new String[] { "share" },
@@ -42,8 +42,8 @@ public class TestContentHandler implements Testlet {
             testInvocation(th);
 
             // Test registering again
-            Registry.getRegistry("RunTests")
-                    .register("RunTests",
+            Registry.getRegistry("RunTestsMIDlet")
+                    .register("RunTestsMIDlet",
                               new String[] { "image/jpeg", "image/png", "image/gif", "audio/amr", "audio/mp3", "video/3gpp", "video/mp4" },
                               null,
                               new String[] { "share" },
@@ -54,7 +54,7 @@ public class TestContentHandler implements Testlet {
             testInvocation(th);
 
             // Test unregistering
-            Registry.getRegistry("RunTests").unregister("RunTests");
+            Registry.getRegistry("RunTestsMIDlet").unregister("RunTestsMIDlet");
 
             try {
                 testInvocation(th);

--- a/tests/javax/microedition/io/TestHttpsConnection.java
+++ b/tests/javax/microedition/io/TestHttpsConnection.java
@@ -1,11 +1,11 @@
 package javax.microedition.io;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import java.io.InputStream;
 import java.io.IOException;
 
-public class TestHttpsConnection implements Testlet {
+public class TestHttpsConnection implements MIDletTestlet {
     public int getExpectedPass() { return 5; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/javax/microedition/lcdui/TestAlert.java
+++ b/tests/javax/microedition/lcdui/TestAlert.java
@@ -4,13 +4,13 @@ package javax.microedition.lcdui;
 
 import com.nokia.mid.ui.TextEditor;
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import javax.microedition.lcdui.Alert;
 import javax.microedition.lcdui.AlertType;
 import javax.microedition.lcdui.Canvas;
 import javax.microedition.lcdui.Graphics;
 
-public class TestAlert extends Canvas implements Testlet {
+public class TestAlert extends Canvas implements MIDletTestlet {
     public int getExpectedPass() { return 8; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/javax/microedition/lcdui/TestTextEditorFocus.java
+++ b/tests/javax/microedition/lcdui/TestTextEditorFocus.java
@@ -4,7 +4,7 @@ package javax.microedition.lcdui;
 
 import com.nokia.mid.ui.TextEditor;
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import javax.microedition.lcdui.Alert;
 import javax.microedition.lcdui.AlertType;
 import javax.microedition.lcdui.Canvas;
@@ -29,7 +29,7 @@ class TestScreenWithoutFocus extends Canvas {
     }
 }
 
-public class TestTextEditorFocus implements Testlet {
+public class TestTextEditorFocus implements MIDletTestlet {
     public int getExpectedPass() { return 9; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 1; }

--- a/tests/javax/microedition/media/TestAudioPlayer.java
+++ b/tests/javax/microedition/media/TestAudioPlayer.java
@@ -1,13 +1,13 @@
 package javax.microedition.media;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import gnu.testlet.TestUtils;
 import javax.microedition.io.*;
 import javax.microedition.io.file.*;
 import java.io.*;
 
-public class TestAudioPlayer implements Testlet, PlayerListener {
+public class TestAudioPlayer implements MIDletTestlet, PlayerListener {
     public int getExpectedPass() { return 21; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/javax/microedition/media/TestPlayTone.java
+++ b/tests/javax/microedition/media/TestPlayTone.java
@@ -3,10 +3,10 @@ package javax.microedition.media;
 import com.sun.mmedia.Configuration;
 import com.sun.mmedia.TonePlayer;
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import javax.microedition.media.control.ToneControl;
 
-public class TestPlayTone implements Testlet {
+public class TestPlayTone implements MIDletTestlet {
     public int getExpectedPass() { return 1; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/javax/microedition/media/TestPlayerListener.java
+++ b/tests/javax/microedition/media/TestPlayerListener.java
@@ -1,10 +1,10 @@
 package javax.microedition.media;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import java.io.InputStream;
 
-public class TestPlayerListener implements Testlet, PlayerListener {
+public class TestPlayerListener implements MIDletTestlet, PlayerListener {
     public int getExpectedPass() { return 2; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/javax/microedition/pim/TestPIM.java
+++ b/tests/javax/microedition/pim/TestPIM.java
@@ -3,9 +3,9 @@ package javax.microedition.pim;
 import java.io.ByteArrayOutputStream;
 import java.util.Enumeration;
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 
-public class TestPIM implements Testlet {
+public class TestPIM implements MIDletTestlet {
     public int getExpectedPass() { return 28; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/javax/microedition/rms/TestRecordStore.java
+++ b/tests/javax/microedition/rms/TestRecordStore.java
@@ -26,11 +26,11 @@
 package javax.microedition.rms;
 
 import gnu.testlet.TestHarness;
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 
 import java.util.Random;
 
-public class TestRecordStore implements Testlet {
+public class TestRecordStore implements MIDletTestlet {
     public int getExpectedPass() { return 15; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 1; }

--- a/tests/javax/wireless/messaging/SendSMSTest.java
+++ b/tests/javax/wireless/messaging/SendSMSTest.java
@@ -1,12 +1,12 @@
 package javax.wireless.messaging;
 
-import gnu.testlet.Testlet;
+import gnu.testlet.MIDletTestlet;
 import gnu.testlet.TestHarness;
 import javax.microedition.io.Connector;
 import javax.wireless.messaging.MessageConnection;
 import javax.wireless.messaging.TextMessage;
 
-public class SendSMSTest implements Testlet {
+public class SendSMSTest implements MIDletTestlet {
     public int getExpectedPass() { return 3; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }

--- a/tests/runtests.jad
+++ b/tests/runtests.jad
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
-MIDlet-1: RunTests,,RunTests
+MIDlet-1: RunTestsMIDlet,,RunTestsMIDlet
 MIDlet-Vendor: Mozilla
-MIDlet-Name: RunTests
+MIDlet-Name: RunTestsMIDlet
 MIDlet-Version: 1.0
 MicroEdition-Configuration: CLDC-1.1
 MicroEdition-Profile: MIDP-2.1


### PR DESCRIPTION
Sometimes it's useful to run tests without launching a MIDlet.
Launching a MIDlet is a quite complex process, so if you're debugging a low-level feature the chances that you can't even start the current test harness are high.