### PR TITLE
don't ignore all exceptions, just SSLEOFError

### DIFF
--- a/tests/sslEchoServer.py
+++ b/tests/sslEchoServer.py
@@ -16,16 +16,20 @@ while True:
                                      certfile="cert.pem",
                                      keyfile="cert.pem",
                                      ssl_version=ssl.PROTOCOL_SSLv3)
-    except ssl.SSLEOFError as e:
+    except ssl.SSLError as e:
         # Catch occurrences of:
-        # ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:581)
+        #   ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:581)
         #
         # In theory, setting ssl_version to ssl.PROTOCOL_TLSv1 will resolve
         # the problem, but it didn't do so for me, and it caused the error:
-        # ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:581)
+        #   ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:581)
         #
         # Whereas the SSLEOFError doesn't prevent the server from working,
         # so we leave ssl_version at ssl.PROTOCOL_SSLv3 and ignore that error.
+        #
+        # If we catch SSLEOFError specifically, then Travis fails with:
+        #   AttributeError: 'module' object has no attribute 'SSLEOFError'
+        # So we catch the more general exception SSLError.
         pass
 
     try:

--- a/tests/sslEchoServer.py
+++ b/tests/sslEchoServer.py
@@ -8,28 +8,37 @@ s.bind(('localhost', 54443))
 s.listen(5)
 
 while True:
-    try:
-        newsocket, fromaddr = s.accept()
+    newsocket, fromaddr = s.accept()
 
+    try:
         connstream = ssl.wrap_socket(newsocket,
                                      server_side=True,
                                      certfile="cert.pem",
                                      keyfile="cert.pem",
                                      ssl_version=ssl.PROTOCOL_SSLv3)
-
-        try:
-            data = connstream.read()
-            while data:
-                connstream.write(data)
-                data = connstream.read()
-        finally:
-            try:
-                connstream.shutdown(socket.SHUT_RDWR)
-            except socket.error as e:
-                # On Mac, if the other side has already closed the connection,
-                # then socket.shutdown will fail, but we can ignore this failure.
-                pass
-
-            connstream.close()
-    except:
+    except ssl.SSLEOFError as e:
+        # Catch occurrences of:
+        # ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:581)
+        #
+        # In theory, setting ssl_version to ssl.PROTOCOL_TLSv1 will resolve
+        # the problem, but it didn't do so for me, and it caused the error:
+        # ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:581)
+        #
+        # Whereas the SSLEOFError doesn't prevent the server from working,
+        # so we leave ssl_version at ssl.PROTOCOL_SSLv3 and ignore that error.
         pass
+
+    try:
+        data = connstream.read()
+        while data:
+            connstream.write(data)
+            data = connstream.read()
+    finally:
+        try:
+            connstream.shutdown(socket.SHUT_RDWR)
+        except socket.error as e:
+            # On Mac, if the other side has already closed the connection,
+            # then socket.shutdown will fail, but we can ignore this failure.
+            pass
+
+        connstream.close()

--- a/tests/sslEchoServer.py
+++ b/tests/sslEchoServer.py
@@ -32,17 +32,18 @@ while True:
         # So we catch the more general exception SSLError.
         pass
 
-    try:
-        data = connstream.read()
-        while data:
-            connstream.write(data)
-            data = connstream.read()
-    finally:
+    if (connstream):
         try:
-            connstream.shutdown(socket.SHUT_RDWR)
-        except socket.error as e:
-            # On Mac, if the other side has already closed the connection,
-            # then socket.shutdown will fail, but we can ignore this failure.
-            pass
+            data = connstream.read()
+            while data:
+                connstream.write(data)
+                data = connstream.read()
+        finally:
+            try:
+                connstream.shutdown(socket.SHUT_RDWR)
+            except socket.error as e:
+                # On Mac, if the other side has already closed the connection,
+                # then socket.shutdown will fail, but we can ignore this failure.
+                pass
 
-        connstream.close()
+            connstream.close()


### PR DESCRIPTION
sslEchoServer.py ignores all exceptions inside its `while True` loop, which makes it unkillable. In my testing, the only exception that actually gets thrown is indeed ignorable, but we should only ignore it for the one line that throws it, so it's possible to kill the server with a timely Ctrl+C.
