### PR TITLE
Inline *read* calls in DataInputStream and *write* calls in DataOutputStream

### DIFF
--- a/bench/DataInputOutputStreamBench.java
+++ b/bench/DataInputOutputStreamBench.java
@@ -13,7 +13,7 @@ public class DataInputOutputStreamBench {
   void writeUTF(OutputStream out) throws IOException {
       DataOutputStream dos = new DataOutputStream(out);
 
-      for (int i = 0; i < 50000; i++) {
+      for (int i = 0; i < 70000; i++) {
           dos.writeUTF("abcdefghilmnopqrstuvzABCDEFGHILMNOPQRSTUVZ");
       }
 
@@ -26,6 +26,26 @@ public class DataInputOutputStreamBench {
 
       for (int i = 0; i < 25000; i++) {
           String str = dis.readUTF();
+      }
+
+      dis.close();
+  }
+
+  void readInt(InputStream is) throws IOException {
+      DataInputStream dis = new DataInputStream(is);
+
+      for (int i = 0; i < 200000; i++) {
+          int aInt = dis.readInt();
+      }
+
+      dis.close();
+  }
+
+  void readShort(InputStream is) throws IOException {
+      DataInputStream dis = new DataInputStream(is);
+
+      for (int i = 0; i < 400000; i++) {
+          int aInt = dis.readShort();
       }
 
       dis.close();
@@ -45,6 +65,14 @@ public class DataInputOutputStreamBench {
           start = JVM.monotonicTimeMillis();
           readUTF(in);
           System.out.println("DataInputStream::readUTF: " + (JVM.monotonicTimeMillis() - start));
+
+          start = JVM.monotonicTimeMillis();
+          readInt(in);
+          System.out.println("DataInputStream::readInt: " + (JVM.monotonicTimeMillis() - start));
+
+          start = JVM.monotonicTimeMillis();
+          readShort(in);
+          System.out.println("DataInputStream::readShort: " + (JVM.monotonicTimeMillis() - start));
       } catch (IOException e) {
           System.out.println("Unexpected exception: " + e);
           e.printStackTrace();

--- a/java/custom/java/io/DataInputStream.java
+++ b/java/custom/java/io/DataInputStream.java
@@ -191,7 +191,7 @@ class DataInputStream extends InputStream implements DataInput {
      * @exception  IOException   if an I/O error occurs.
      */
     public final boolean readBoolean() throws IOException {
-        int ch = read();
+        int ch = in.read();
         if (ch < 0) {
             throw new EOFException();
         }
@@ -211,7 +211,7 @@ class DataInputStream extends InputStream implements DataInput {
      * @exception  IOException   if an I/O error occurs.
      */
     public final byte readByte() throws IOException {
-        int ch = read();
+        int ch = in.read();
         if (ch < 0) {
             throw new EOFException();
         }
@@ -231,7 +231,7 @@ class DataInputStream extends InputStream implements DataInput {
      * @exception  IOException   if an I/O error occurs.
      */
     public final int readUnsignedByte() throws IOException {
-        int ch = read();
+        int ch = in.read();
         if (ch < 0) {
             throw new EOFException();
         }
@@ -252,7 +252,12 @@ class DataInputStream extends InputStream implements DataInput {
      * @exception  IOException   if an I/O error occurs.
      */
     public final short readShort() throws IOException {
-        return (short)readUnsignedShort();
+        int ch1 = in.read();
+        int ch2 = in.read();
+        if ((ch1 | ch2) < 0) {
+             throw new EOFException();
+        }
+        return (short)((ch1 << 8) + (ch2 << 0));
     }
 
     /**
@@ -269,8 +274,8 @@ class DataInputStream extends InputStream implements DataInput {
      * @exception  IOException   if an I/O error occurs.
      */
     public final int readUnsignedShort() throws IOException {
-        int ch1 = read();
-        int ch2 = read();
+        int ch1 = in.read();
+        int ch2 = in.read();
         if ((ch1 | ch2) < 0) {
              throw new EOFException();
         }
@@ -308,10 +313,10 @@ class DataInputStream extends InputStream implements DataInput {
      * @exception  IOException   if an I/O error occurs.
      */
     public final int readInt() throws IOException {
-        int ch1 = read();
-        int ch2 = read();
-        int ch3 = read();
-        int ch4 = read();
+        int ch1 = in.read();
+        int ch2 = in.read();
+        int ch3 = in.read();
+        int ch4 = in.read();
         if ((ch1 | ch2 | ch3 | ch4) < 0) {
              throw new EOFException();
         }

--- a/java/custom/java/io/DataOutputStream.java
+++ b/java/custom/java/io/DataOutputStream.java
@@ -105,7 +105,7 @@ class DataOutputStream extends OutputStream implements DataOutput {
      */
     public void close() throws IOException {
         try {
-            flush();
+            out.flush();
         } catch (IOException e) {
         }
         out.close();
@@ -121,7 +121,7 @@ class DataOutputStream extends OutputStream implements DataOutput {
      * @exception  IOException  if an I/O error occurs.
      */
     public final void writeBoolean(boolean v) throws IOException {
-        write(v ? 1 : 0);
+        out.write(v ? 1 : 0);
     }
 
     /**
@@ -132,7 +132,7 @@ class DataOutputStream extends OutputStream implements DataOutput {
      * @exception  IOException  if an I/O error occurs.
      */
     public final void writeByte(int v) throws IOException {
-        write(v);
+        out.write(v);
     }
 
     /**
@@ -143,8 +143,8 @@ class DataOutputStream extends OutputStream implements DataOutput {
      * @exception  IOException  if an I/O error occurs.
      */
     public final void writeShort(int v) throws IOException {
-        write((v >>> 8) & 0xFF);
-        write((v >>> 0) & 0xFF);
+        out.write((v >>> 8) & 0xFF);
+        out.write((v >>> 0) & 0xFF);
     }
 
     /**
@@ -155,8 +155,8 @@ class DataOutputStream extends OutputStream implements DataOutput {
      * @exception  IOException  if an I/O error occurs.
      */
     public final void writeChar(int v) throws IOException {
-        write((v >>> 8) & 0xFF);
-        write((v >>> 0) & 0xFF);
+        out.write((v >>> 8) & 0xFF);
+        out.write((v >>> 0) & 0xFF);
     }
 
     /**
@@ -167,10 +167,10 @@ class DataOutputStream extends OutputStream implements DataOutput {
      * @exception  IOException  if an I/O error occurs.
      */
     public final void writeInt(int v) throws IOException {
-        write((v >>> 24) & 0xFF);
-        write((v >>> 16) & 0xFF);
-        write((v >>>  8) & 0xFF);
-        write((v >>>  0) & 0xFF);
+        out.write((v >>> 24) & 0xFF);
+        out.write((v >>> 16) & 0xFF);
+        out.write((v >>>  8) & 0xFF);
+        out.write((v >>>  0) & 0xFF);
     }
 
     /**
@@ -181,14 +181,14 @@ class DataOutputStream extends OutputStream implements DataOutput {
      * @exception  IOException  if an I/O error occurs.
      */
     public final void writeLong(long v) throws IOException {
-        write((int)(v >>> 56) & 0xFF);
-        write((int)(v >>> 48) & 0xFF);
-        write((int)(v >>> 40) & 0xFF);
-        write((int)(v >>> 32) & 0xFF);
-        write((int)(v >>> 24) & 0xFF);
-        write((int)(v >>> 16) & 0xFF);
-        write((int)(v >>>  8) & 0xFF);
-        write((int)(v >>>  0) & 0xFF);
+        out.write((int)(v >>> 56) & 0xFF);
+        out.write((int)(v >>> 48) & 0xFF);
+        out.write((int)(v >>> 40) & 0xFF);
+        out.write((int)(v >>> 32) & 0xFF);
+        out.write((int)(v >>> 24) & 0xFF);
+        out.write((int)(v >>> 16) & 0xFF);
+        out.write((int)(v >>>  8) & 0xFF);
+        out.write((int)(v >>>  0) & 0xFF);
     }
 
     /**
@@ -234,8 +234,8 @@ class DataOutputStream extends OutputStream implements DataOutput {
         int len = s.length();
         for (int i = 0 ; i < len ; i++) {
             int v = s.charAt(i);
-            write((v >>> 8) & 0xFF);
-            write((v >>> 0) & 0xFF);
+            out.write((v >>> 8) & 0xFF);
+            out.write((v >>> 0) & 0xFF);
         }
     }
 
@@ -274,8 +274,9 @@ class DataOutputStream extends OutputStream implements DataOutput {
      */
     static final int writeUTF(String str, DataOutput out) throws IOException {
         byte[] bytearr = UTFToBytes(str);
-        out.write(bytearr);
-        return bytearr.length;
+        int len = bytearr.length;
+        out.write(bytearr, 0, len);
+        return len;
     }
 
     static native byte[] UTFToBytes(String str);


### PR DESCRIPTION
I've noticed *readInt* and *readShort* are called many times during startup of a MIDlet. This micro-optimization improves their perf by nearly 2x.