### PR TITLE
Remove security checks from Thread and System

### DIFF
--- a/aot-methods.txt
+++ b/aot-methods.txt
@@ -1,5 +1,4 @@
 java/util/Vector.indexOf.(Ljava/lang/Object;I)I
-java/util/PropertyPermission.getActions.(I)Ljava/lang/String;
 java/util/Vector.addElement.(Ljava/lang/Object;)V
 java/util/Vector.size.()I
 java/util/Vector.elementAt.(I)Ljava/lang/Object;
@@ -10,17 +9,10 @@ com/sun/cldc/i18n/uclc/DefaultCaseConverter.isDigit.(C)Z
 com/nokia/mid/ui/DirectUtils.getDirectGraphics.(Ljavax/microedition/lcdui/Graphics;)Lcom/nokia/mid/ui/DirectGraphics;
 com/nokia/mid/ui/DirectGraphicsImp.<init>.(Ljavax/microedition/lcdui/Graphics;)V
 javax/microedition/lcdui/Font.getHeight.()I
-java/security/Permission.<init>.(Ljava/lang/String;)V
-java/security/BasicPermission.init.(Ljava/lang/String;)V
 java/security/AccessController.checkPermission.(Ljava/security/Permission;)V
 java/lang/Character.digit.(CI)I
 com/sun/cldc/i18n/uclc/DefaultCaseConverter.digit.(CI)I
-java/util/PropertyPermission.getMask.(Ljava/lang/String;)I
 java/lang/System.getProperty.(Ljava/lang/String;)Ljava/lang/String;
-java/util/PropertyPermission.<init>.(Ljava/lang/String;Ljava/lang/String;)V
-java/security/BasicPermission.<init>.(Ljava/lang/String;Ljava/lang/String;)V
-java/util/PropertyPermission.init.(I)V
-java/security/Permission.getName.()Ljava/lang/String;
 java/util/Vector.<init>.(II)V
 java/util/Vector.<init>.(I)V
 java/util/Vector.<init>.()V
@@ -221,7 +213,6 @@ java/lang/Thread.getPriority.()I
 java/lang/Thread.setPriority.(I)V
 java/lang/Thread.checkAccess.()V
 java/lang/RuntimePermission.<init>.(Ljava/lang/String;)V
-java/security/BasicPermission.<init>.(Ljava/lang/String;)V
 java/util/Vector.setSize.(I)V
 java/io/ByteArrayOutputStream.size.()I
 java/lang/Thread.nextThreadNum.()I

--- a/java/custom/java/lang/System.java
+++ b/java/custom/java/lang/System.java
@@ -28,9 +28,6 @@ package java.lang;
 
 import java.io.*;
 import com.sun.cldchi.io.*;
-import java.security.*;
-import java.util.PropertyPermission;
-
 
 /**
  * The <code>System</code> class contains several useful class fields
@@ -241,8 +238,6 @@ public final class System {
 /* #endif */
             );
         }
-        Permission required_permission = new PropertyPermission(key, "read");
-        AccessController.checkPermission(required_permission);
         return getProperty0(key);
     }
 

--- a/java/custom/java/lang/Thread.java
+++ b/java/custom/java/lang/Thread.java
@@ -26,8 +26,6 @@
 
 package java.lang;
 
-import java.security.*;
-
 /**
  * A <i>thread</i> is a thread of execution in a program. The Java
  * Virtual Machine allows an application to have multiple threads of
@@ -277,7 +275,6 @@ class Thread implements Runnable {
      * @since JDK 1.0, CLDC 1.1
      */
     public void interrupt() {
-        checkAccess();
         interrupt0();
     }
 
@@ -306,7 +303,6 @@ class Thread implements Runnable {
         if (newPriority > MAX_PRIORITY || newPriority < MIN_PRIORITY) {
             throw new IllegalArgumentException();
         }
-        checkAccess();
         setPriority0(priority, newPriority);
         priority = newPriority;
     }
@@ -382,7 +378,6 @@ class Thread implements Runnable {
      * @see       AccessController.checkPermission(java.security.Permission), RuntimePermission  
      */
     public final void checkAccess() {
-      Permission required = new RuntimePermission("modifyThread");
-      AccessController.checkPermission(required);
+        // Removed for performance reasons.
     }
 }


### PR DESCRIPTION
According to a profile, these functions are called a lot.
The behavior of the functions is actually left unchanged, because `AccessController::checkPermission` is a no-op (its functions are commented out, not only in our repo but also in phoneME).

*checkAccess* is taking ~18 ms during startup on my machine (which is usually more than 10x faster in CPU-bound tasks than a Flame).

*getProperty*, instead, is taking ~60 ms.

Removing these security checks allows us to remove PropertyPermission and BasicPermission methods from aot-methods.txt.